### PR TITLE
feat: 可自定义键位配置 | customizable keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,117 @@ scroll_amount = 3
 aggregate_search = true
 show_cover = true
 max_fps = 20
+
+
 ```
+
+## 键位配置
+
+voicefox 支持通过配置文件自定义快捷键，无需修改代码。配置文件位置：`~/.config/voicefox/config.toml`。
+
+未在配置中指定的键位保持默认行为，因此你只需要修改想要改变的键位即可。
+
+### 键位格式
+
+| 格式 | 示例 | 说明 |
+|------|------|------|
+| 单字符 | `"q"` `"n"` `"j"` | 字母、数字、标点 |
+| 特殊键 | `"Space"` `"Tab"` `"Esc"` `"Enter"` `"Backspace"` | 功能键名 |
+| 方向键 | `"Up"` `"Down"` `"Left"` `"Right"` | 方向键 |
+| 翻页键 | `"PageUp"` `"PageDown"` `"Home"` `"End"` | 翻页和跳转 |
+| 功能键 | `"F1"` ~ `"F12"` | F1 到 F12 |
+| 组合键 | `"Ctrl+l"` `"Shift+Tab"` `"Alt+Enter"` | Ctrl / Shift / Alt 组合 |
+
+键名不区分大小写，`"k"` 和 `"K"` 效果相同。
+
+### 全局可配置动作
+
+在 `[keybindings.global]` 下配置，以下动作在所有页面都生效：
+
+| 配置项 | 默认值 | 功能 |
+|--------|--------|------|
+| `global_quit` | `"q"` | 退出应用 |
+| `global_play_pause` | `"Space"` | 播放 / 暂停 |
+| `global_next_track` | `"n"` | 下一首 |
+| `global_prev_track` | `"b"` | 上一首 |
+| `global_cycle_mode` | `"m"` | 切换播放模式 |
+| `global_seek_forward` | `"]"` | 快进 5 秒 |
+| `global_seek_backward` | `"["` | 后退 5 秒 |
+| `global_volume_up` | `"."` | 音量增加 |
+| `global_volume_down` | `","` | 音量减少 |
+| `global_next_tab` | `"Tab"` | 下一个标签页 |
+| `global_prev_tab` | `"Shift+Tab"` | 上一个标签页 |
+| `global_go_to_main` | `"Esc"` | 返回主界面 |
+| `global_toggle_favorite` | `"Ctrl+l"` | 收藏 / 取消收藏 |
+
+### 页面级可配置动作
+
+在 `[keybindings.pages.<页面名>]` 下配置。以下动作只在对应页面生效。
+
+**通用列表动作**（搜索、队列、排行榜、歌单、收藏、历史、本地音乐、设置 都支持）：
+
+| 配置项 | 默认值 | 功能 |
+|--------|--------|------|
+| `list_select_up` | `"k"` | 选择上一项 |
+| `list_select_down` | `"j"` | 选择下一项 |
+| `list_select_first` | `"g"` | 跳到第一项 |
+| `list_select_last` | `"G"` | 跳到最后一项 |
+| `list_page_up` | `"Ctrl+u"` | 向上翻页 |
+| `list_page_down` | `"Ctrl+d"` | 向下翻页 |
+| `list_activate` | `"Enter"` 或 `"l"` | 播放 / 进入 / 激活 |
+| `list_go_back` | `"Esc"` | 返回 / 退出 |
+| `list_add_to_queue` | `"a"` | 添加到队列尾部 |
+| `list_add_to_queue_next` | `"A"` | 插到下一首播放 |
+
+**搜索页面专用**：
+
+| 配置项 | 默认值 | 功能 |
+|--------|--------|------|
+| `search_input_mode` | `"i"` | 进入搜索输入模式 |
+| `search_start` | `"Enter"` | 开始搜索 / 播放结果 |
+| `search_toggle_aggregate` | `"v"` | 切换聚合 / 单音源搜索 |
+| `search_cycle_source_prev` | `"Left"` | 切换上一个音源 |
+| `search_cycle_source_next` | `"Right"` | 切换下一个音源 |
+
+**收藏页面专用**：
+
+| 配置项 | 默认值 | 功能 |
+|--------|--------|------|
+| `favorites_filter` | `"/"` | 进入过滤模式 |
+| `favorites_remove` | `"d"` | 取消收藏选中歌曲 |
+
+**本地音乐页面专用**：
+
+| 配置项 | 默认值 | 功能 |
+|--------|--------|------|
+| `local_rescan` | `"r"` | 重新扫描本地目录 |
+| `local_delete` | `"d"` | 删除选中文件（弹出确认） |
+
+### 配置示例
+
+以下示例只修改了部分键位，其余未指定的键位保持默认：
+
+```toml
+[keybindings.global]
+global_next_track = "k"
+
+[keybindings.pages.search]
+list_select_up = "e"
+list_select_down = "n"
+```
+
+### 页面名列表
+
+`[keybindings.pages.<页面名>]` 中的 `<页面名>` 必须是以下之一：
+
+- `main` — 队列页面（主页）
+- `search` — 搜索页面
+- `leaderboard` — 排行榜页面
+- `playlists` — 热门歌单页面
+- `favorites` — 收藏页面
+- `history` — 历史页面
+- `local` — 本地音乐页面
+- `settings` — 设置页面
 
 ## 音源说明
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -24,6 +24,7 @@ use crossterm::event::{
     MouseButton, MouseEvent, MouseEventKind,
 };
 use lx_core::events::{AppAction, InsertPosition, Notification};
+use lx_core::keybinding::{Action, KeybindingResolver};
 use lx_core::model::leaderboard::LeaderboardInfo;
 use lx_core::model::playlist::Playlist;
 use lx_core::model::song::SongInfo;
@@ -230,6 +231,10 @@ fn run_app(
     let search_seq: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));
     let mut leaderboard_request_id: u64 = 0;
     let mut playlist_request_id: u64 = 0;
+
+    // 键位解析器（从配置加载自定义键位）
+    let keybindings = ctx.config.read().unwrap().keybindings.clone();
+    let kb_resolver = KeybindingResolver::from_config(&keybindings);
 
     // 导航状态
     let mut active_tab = NavTab::Main;
@@ -742,7 +747,7 @@ fn run_app(
                 settings_input_mode || search_input_mode || favorites_input_mode;
 
             if let Some(ref page) = bili_login_page {
-                let action = page.lock().unwrap().handle_input(key);
+                let action = page.lock().unwrap().handle_input(key, &kb_resolver);
                 match action {
                     AppAction::BiliLoginSuccess => {
                         let _ = action_tx.send(AppAction::BiliLoginSuccess);
@@ -826,53 +831,174 @@ fn run_app(
                 continue;
             }
 
-            // 1b. 全局快捷键
-            match (key.modifiers, key.code) {
-                (KeyModifiers::NONE, KeyCode::Char('q')) if !text_input_active => {
-                    tracing::info!("quit requested");
-                    ctx.player.stop();
-                    ctx.cover_service.clear_display();
-                    return Ok(());
-                }
-                (KeyModifiers::NONE, KeyCode::Char(' ')) if !text_input_active => {
-                    ctx.player.toggle();
-                    needs_render = true;
-                    continue;
-                }
-                (KeyModifiers::NONE, KeyCode::Char('n')) if !text_input_active => {
-                    if let Some((songs, index)) = ctx.playlist.next_manual_entry() {
-                        execute_action(
-                            AppAction::PlaySong { songs, index },
-                            &ctx,
-                            rt,
-                            &action_tx,
-                            &search_page,
-                            &settings_page,
-                            &search_seq,
-                        );
+            // 1b. 全局快捷键（查表模式，保留完全相同的默认行为）
+            if let Some(action) = kb_resolver.resolve_global(&key) {
+                match action {
+                    Action::GlobalQuit if !text_input_active => {
+                        tracing::info!("quit requested");
+                        ctx.player.stop();
+                        ctx.cover_service.clear_display();
+                        return Ok(());
                     }
-                    needs_render = true;
-                    continue;
+                    Action::GlobalPlayPause if !text_input_active => {
+                        ctx.player.toggle();
+                        needs_render = true;
+                        continue;
+                    }
+                    Action::GlobalNextTrack if !text_input_active => {
+                        if let Some((songs, index)) = ctx.playlist.next_manual_entry() {
+                            execute_action(
+                                AppAction::PlaySong { songs, index },
+                                &ctx,
+                                rt,
+                                &action_tx,
+                                &search_page,
+                                &settings_page,
+                                &search_seq,
+                            );
+                        }
+                        needs_render = true;
+                        continue;
+                    }
+                    Action::GlobalPrevTrack
+                        if !text_input_active && active_tab != NavTab::Settings =>
+                    {
+                        if let Some((songs, index)) = ctx.playlist.prev_manual_entry() {
+                            execute_action(
+                                AppAction::PlaySong { songs, index },
+                                &ctx,
+                                rt,
+                                &action_tx,
+                                &search_page,
+                                &settings_page,
+                                &search_seq,
+                            );
+                        }
+                        needs_render = true;
+                        continue;
+                    }
+                    Action::GlobalCycleMode if !text_input_active => {
+                        let mode = ctx.playlist.cycle_mode();
+                        let save_result = {
+                            let mut config = ctx.config.write().unwrap();
+                            config.player.play_mode = mode.as_config().to_string();
+                            crate::config::loader::save(&config, &ctx.config_path)
+                        };
+                        let notification = match save_result {
+                            Ok(()) => Notification::info(format!("播放模式: {}", mode.label())),
+                            Err(error) => {
+                                Notification::error(format!("播放模式已切换，但保存失败: {}", error))
+                            }
+                        };
+                        ctx.notifications.write().unwrap().push_back(notification);
+                        needs_render = true;
+                        continue;
+                    }
+                    Action::GlobalSeekForward
+                        if !text_input_active
+                            && active_tab != NavTab::Leaderboard
+                            && active_tab != NavTab::Playlists =>
+                    {
+                        let pos = *ctx.position.borrow();
+                        ctx.player.seek(pos + Duration::from_secs(5));
+                        needs_render = true;
+                        continue;
+                    }
+                    Action::GlobalSeekBackward
+                        if !text_input_active
+                            && active_tab != NavTab::Leaderboard
+                            && active_tab != NavTab::Playlists =>
+                    {
+                        let pos = *ctx.position.borrow();
+                        if pos > Duration::from_secs(5) {
+                            ctx.player.seek(pos - Duration::from_secs(5));
+                        } else {
+                            ctx.player.seek(Duration::ZERO);
+                        }
+                        needs_render = true;
+                        continue;
+                    }
+                    Action::GlobalVolumeUp if !text_input_active => {
+                        ctx.player.volume_up(5);
+                        needs_render = true;
+                        continue;
+                    }
+                    Action::GlobalVolumeDown if !text_input_active => {
+                        ctx.player.volume_down(5);
+                        needs_render = true;
+                        continue;
+                    }
+                    Action::GlobalNextTab if !text_input_active => {
+                        active_tab = match active_tab {
+                            NavTab::Main => NavTab::Search,
+                            NavTab::Search => NavTab::Leaderboard,
+                            NavTab::Leaderboard => NavTab::Playlists,
+                            NavTab::Playlists => NavTab::Favorites,
+                            NavTab::Favorites => NavTab::History,
+                            NavTab::History => NavTab::LocalMusic,
+                            NavTab::LocalMusic => NavTab::Settings,
+                            NavTab::Settings => NavTab::Main,
+                        };
+                        needs_render = true;
+                        continue;
+                    }
+                    Action::GlobalPrevTab if !text_input_active => {
+                        active_tab = match active_tab {
+                            NavTab::Main => NavTab::Settings,
+                            NavTab::Search => NavTab::Main,
+                            NavTab::Leaderboard => NavTab::Search,
+                            NavTab::Playlists => NavTab::Leaderboard,
+                            NavTab::Favorites => NavTab::Playlists,
+                            NavTab::History => NavTab::Favorites,
+                            NavTab::LocalMusic => NavTab::History,
+                            NavTab::Settings => NavTab::LocalMusic,
+                        };
+                        needs_render = true;
+                        continue;
+                    }
+                    Action::GlobalGoToMain
+                        if !settings_input_mode
+                            && active_tab != NavTab::Main
+                            && active_tab != NavTab::Search
+                            && active_tab != NavTab::Favorites
+                            && !(active_tab == NavTab::Playlists
+                                && playlists.selected_playlist.is_some())
+                            && !(active_tab == NavTab::Leaderboard
+                                && leaderboard.selected_board.is_some()) =>
+                    {
+                        active_tab = NavTab::Main;
+                        needs_render = true;
+                        continue;
+                    }
+                    Action::GlobalToggleFavorite
+                        if !text_input_active
+                            && active_tab != NavTab::Favorites
+                            && active_tab != NavTab::Playlists =>
+                    {
+                        if let Some(song) = ctx.current_song.read().unwrap().as_ref() {
+                            if ctx.storage.is_favorite(song) {
+                                ctx.storage.remove_favorite(song);
+                                let _ = action_tx.send(AppAction::ShowNotification(
+                                    Notification::info("已取消收藏"),
+                                ));
+                            } else {
+                                ctx.storage.add_favorite(song);
+                                let _ = action_tx.send(AppAction::ShowNotification(
+                                    Notification::info("已添加收藏"),
+                                ));
+                            }
+                        }
+                        needs_render = true;
+                        continue;
+                    }
+                    _ => {}
                 }
+            }
+
+            // Fallback：不在自定义配置中的全局键位别名（保持向后兼容）
+            match (key.modifiers, key.code) {
                 (KeyModifiers::SHIFT, KeyCode::Char('>')) if !text_input_active => {
                     if let Some((songs, index)) = ctx.playlist.next_manual_entry() {
-                        execute_action(
-                            AppAction::PlaySong { songs, index },
-                            &ctx,
-                            rt,
-                            &action_tx,
-                            &search_page,
-                            &settings_page,
-                            &search_seq,
-                        );
-                    }
-                    needs_render = true;
-                    continue;
-                }
-                (KeyModifiers::NONE, KeyCode::Char('b'))
-                    if !text_input_active && active_tab != NavTab::Settings =>
-                {
-                    if let Some((songs, index)) = ctx.playlist.prev_manual_entry() {
                         execute_action(
                             AppAction::PlaySong { songs, index },
                             &ctx,
@@ -898,23 +1024,6 @@ fn run_app(
                             &search_seq,
                         );
                     }
-                    needs_render = true;
-                    continue;
-                }
-                (KeyModifiers::NONE, KeyCode::Char('m')) if !text_input_active => {
-                    let mode = ctx.playlist.cycle_mode();
-                    let save_result = {
-                        let mut config = ctx.config.write().unwrap();
-                        config.player.play_mode = mode.as_config().to_string();
-                        crate::config::loader::save(&config, &ctx.config_path)
-                    };
-                    let notification = match save_result {
-                        Ok(()) => Notification::info(format!("播放模式: {}", mode.label())),
-                        Err(error) => {
-                            Notification::error(format!("播放模式已切换，但保存失败: {}", error))
-                        }
-                    };
-                    ctx.notifications.write().unwrap().push_back(notification);
                     needs_render = true;
                     continue;
                 }
@@ -944,30 +1053,6 @@ fn run_app(
                     needs_render = true;
                     continue;
                 }
-                (KeyModifiers::NONE, KeyCode::Char(']'))
-                    if !text_input_active
-                        && active_tab != NavTab::Leaderboard
-                        && active_tab != NavTab::Playlists =>
-                {
-                    let pos = *ctx.position.borrow();
-                    ctx.player.seek(pos + Duration::from_secs(5));
-                    needs_render = true;
-                    continue;
-                }
-                (KeyModifiers::NONE, KeyCode::Char('['))
-                    if !text_input_active
-                        && active_tab != NavTab::Leaderboard
-                        && active_tab != NavTab::Playlists =>
-                {
-                    let pos = *ctx.position.borrow();
-                    if pos > Duration::from_secs(5) {
-                        ctx.player.seek(pos - Duration::from_secs(5));
-                    } else {
-                        ctx.player.seek(Duration::ZERO);
-                    }
-                    needs_render = true;
-                    continue;
-                }
                 (KeyModifiers::NONE, KeyCode::Up) if active_tab == NavTab::Main => {
                     ctx.player.volume_up(5);
                     needs_render = true;
@@ -975,80 +1060,6 @@ fn run_app(
                 }
                 (KeyModifiers::NONE, KeyCode::Down) if active_tab == NavTab::Main => {
                     ctx.player.volume_down(5);
-                    needs_render = true;
-                    continue;
-                }
-                (KeyModifiers::NONE, KeyCode::Char('.')) if !text_input_active => {
-                    ctx.player.volume_up(5);
-                    needs_render = true;
-                    continue;
-                }
-                (KeyModifiers::NONE, KeyCode::Char(',')) if !text_input_active => {
-                    ctx.player.volume_down(5);
-                    needs_render = true;
-                    continue;
-                }
-                (KeyModifiers::NONE, KeyCode::Tab) if !text_input_active => {
-                    active_tab = match active_tab {
-                        NavTab::Main => NavTab::Search,
-                        NavTab::Search => NavTab::Leaderboard,
-                        NavTab::Leaderboard => NavTab::Playlists,
-                        NavTab::Playlists => NavTab::Favorites,
-                        NavTab::Favorites => NavTab::History,
-                        NavTab::History => NavTab::LocalMusic,
-                        NavTab::LocalMusic => NavTab::Settings,
-                        NavTab::Settings => NavTab::Main,
-                    };
-                    needs_render = true;
-                    continue;
-                }
-                (KeyModifiers::SHIFT, KeyCode::BackTab) if !text_input_active => {
-                    active_tab = match active_tab {
-                        NavTab::Main => NavTab::Settings,
-                        NavTab::Search => NavTab::Main,
-                        NavTab::Leaderboard => NavTab::Search,
-                        NavTab::Playlists => NavTab::Leaderboard,
-                        NavTab::Favorites => NavTab::Playlists,
-                        NavTab::History => NavTab::Favorites,
-                        NavTab::LocalMusic => NavTab::History,
-                        NavTab::Settings => NavTab::LocalMusic,
-                    };
-                    needs_render = true;
-                    continue;
-                }
-                (KeyModifiers::NONE, KeyCode::Esc)
-                    if !settings_input_mode
-                        && active_tab != NavTab::Main
-                        && active_tab != NavTab::Search
-                        && active_tab != NavTab::Favorites
-                        && !(active_tab == NavTab::Playlists
-                            && playlists.selected_playlist.is_some())
-                        && !(active_tab == NavTab::Leaderboard
-                            && leaderboard.selected_board.is_some()) =>
-                {
-                    active_tab = NavTab::Main;
-                    needs_render = true;
-                    continue;
-                }
-                // Ctrl+L: 收藏/取消收藏当前歌曲
-                (KeyModifiers::CONTROL, KeyCode::Char('l'))
-                    if !text_input_active
-                        && active_tab != NavTab::Favorites
-                        && active_tab != NavTab::Playlists =>
-                {
-                    if let Some(song) = ctx.current_song.read().unwrap().as_ref() {
-                        if ctx.storage.is_favorite(song) {
-                            ctx.storage.remove_favorite(song);
-                            let _ = action_tx.send(AppAction::ShowNotification(
-                                Notification::info("已取消收藏"),
-                            ));
-                        } else {
-                            ctx.storage.add_favorite(song);
-                            let _ = action_tx.send(AppAction::ShowNotification(
-                                Notification::info("已添加收藏"),
-                            ));
-                        }
-                    }
                     needs_render = true;
                     continue;
                 }
@@ -1060,7 +1071,7 @@ fn run_app(
                 NavTab::Search => {
                     let action = {
                         let mut sp = search_page.lock().unwrap();
-                        sp.handle_input(key)
+                        sp.handle_input(key, &kb_resolver)
                     };
                     if matches!(action, AppAction::GoBack) {
                         active_tab = NavTab::Main;
@@ -1078,7 +1089,7 @@ fn run_app(
                     );
                 }
                 NavTab::Main => {
-                    let action = main_page.handle_input(&key, &ctx);
+                    let action = main_page.handle_input(&key, &ctx, &kb_resolver);
                     execute_action(
                         action,
                         &ctx,
@@ -1090,7 +1101,7 @@ fn run_app(
                     );
                 }
                 NavTab::Leaderboard => {
-                    let action = leaderboard.handle_input(&key, &ctx);
+                    let action = leaderboard.handle_input(&key, &ctx, &kb_resolver);
                     execute_action(
                         action,
                         &ctx,
@@ -1102,7 +1113,7 @@ fn run_app(
                     );
                 }
                 NavTab::Playlists => {
-                    let action = playlists.handle_input(&key, &ctx);
+                    let action = playlists.handle_input(&key, &ctx, &kb_resolver);
                     execute_action(
                         action,
                         &ctx,
@@ -1114,7 +1125,7 @@ fn run_app(
                     );
                 }
                 NavTab::Favorites => {
-                    let action = favorites_page.handle_input(&key, &ctx);
+                    let action = favorites_page.handle_input(&key, &ctx, &kb_resolver);
                     if matches!(action, AppAction::GoBack) {
                         active_tab = NavTab::Main;
                         needs_render = true;
@@ -1131,7 +1142,7 @@ fn run_app(
                     );
                 }
                 NavTab::History => {
-                    let action = pages::history::handle_input(&key, &ctx, &mut history_selected);
+                    let action = pages::history::handle_input(&key, &ctx, &mut history_selected, &kb_resolver);
                     // 保持在历史页面，不强制切换到主页
                     execute_action(
                         action,
@@ -1146,7 +1157,7 @@ fn run_app(
                 NavTab::Settings => {
                     let action = {
                         let mut sp = settings_page.lock().unwrap();
-                        sp.handle_input(key, &ctx)
+                        sp.handle_input(key, &ctx, &kb_resolver)
                     };
                     // BiliLogin/BiliLogout 需要发到 channel 让主循环处理（生成 QR 码等）
                     if matches!(
@@ -1178,63 +1189,13 @@ fn run_app(
                 NavTab::LocalMusic => {
                     let local_src = ctx.source_manager.local_source();
                     let songs = local_src.all_songs();
-                    match (key.modifiers, key.code) {
-                        (KeyModifiers::NONE, KeyCode::Char('r')) => {
-                            let paths = ctx.config.read().unwrap().local_music.paths.clone();
-                            let max_depth = ctx.config.read().unwrap().local_music.max_depth;
-                            execute_action(
-                                AppAction::ScanLocalMusic { paths, max_depth },
-                                &ctx,
-                                rt,
-                                &action_tx,
-                                &search_page,
-                                &settings_page,
-                                &search_seq,
-                            );
-                            local_selected = 0;
-                            local_scroll = 0;
-                        }
-                        (KeyModifiers::NONE, KeyCode::Up)
-                        | (KeyModifiers::NONE, KeyCode::Char('k')) => {
-                            local_selected = previous_list_index(
-                                local_selected,
-                                songs.len(),
-                                ctx.config.read().unwrap().ui.wrap_navigation,
-                            );
-                        }
-                        (KeyModifiers::NONE, KeyCode::Down)
-                        | (KeyModifiers::NONE, KeyCode::Char('j')) => {
-                            local_selected = next_list_index(
-                                local_selected,
-                                songs.len(),
-                                ctx.config.read().unwrap().ui.wrap_navigation,
-                            );
-                        }
-                        (KeyModifiers::NONE, KeyCode::Home)
-                        | (KeyModifiers::NONE, KeyCode::Char('g')) => {
-                            local_selected = 0;
-                        }
-                        (KeyModifiers::NONE, KeyCode::End)
-                        | (KeyModifiers::NONE, KeyCode::Char('G'))
-                        | (KeyModifiers::SHIFT, KeyCode::Char('G')) => {
-                            local_selected = songs.len().saturating_sub(1);
-                        }
-                        (KeyModifiers::CONTROL, KeyCode::Char('u'))
-                        | (KeyModifiers::NONE, KeyCode::PageUp) => {
-                            local_selected = local_selected.saturating_sub(10);
-                        }
-                        (KeyModifiers::CONTROL, KeyCode::Char('d'))
-                        | (KeyModifiers::NONE, KeyCode::PageDown) => {
-                            local_selected =
-                                (local_selected + 10).min(songs.len().saturating_sub(1));
-                        }
-                        _ if pages::is_song_activation_key(&key) => {
-                            if !songs.is_empty() && local_selected < songs.len() {
+                    if let Some(action) = kb_resolver.resolve_page("local", &key) {
+                        match action {
+                            Action::LocalRescan => {
+                                let paths = ctx.config.read().unwrap().local_music.paths.clone();
+                                let max_depth = ctx.config.read().unwrap().local_music.max_depth;
                                 execute_action(
-                                    AppAction::PlaySong {
-                                        songs,
-                                        index: local_selected,
-                                    },
+                                    AppAction::ScanLocalMusic { paths, max_depth },
                                     &ctx,
                                     rt,
                                     &action_tx,
@@ -1242,57 +1203,215 @@ fn run_app(
                                     &settings_page,
                                     &search_seq,
                                 );
+                                local_selected = 0;
+                                local_scroll = 0;
                             }
-                        }
-                        (KeyModifiers::NONE, KeyCode::Char('a')) => {
-                            if let Some(song) = songs.get(local_selected).cloned() {
-                                execute_action(
-                                    AppAction::AddToQueue {
-                                        song: Box::new(song),
-                                        position: InsertPosition::End,
-                                    },
-                                    &ctx,
-                                    rt,
-                                    &action_tx,
-                                    &search_page,
-                                    &settings_page,
-                                    &search_seq,
+                            Action::ListSelectUp => {
+                                local_selected = previous_list_index(
+                                    local_selected,
+                                    songs.len(),
+                                    ctx.config.read().unwrap().ui.wrap_navigation,
                                 );
                             }
-                        }
-                        (KeyModifiers::NONE, KeyCode::Char('A'))
-                        | (KeyModifiers::SHIFT, KeyCode::Char('A')) => {
-                            if let Some(song) = songs.get(local_selected).cloned() {
-                                execute_action(
-                                    AppAction::AddToQueue {
-                                        song: Box::new(song),
-                                        position: InsertPosition::Next,
-                                    },
-                                    &ctx,
-                                    rt,
-                                    &action_tx,
-                                    &search_page,
-                                    &settings_page,
-                                    &search_seq,
+                            Action::ListSelectDown => {
+                                local_selected = next_list_index(
+                                    local_selected,
+                                    songs.len(),
+                                    ctx.config.read().unwrap().ui.wrap_navigation,
                                 );
                             }
-                        }
-                        (KeyModifiers::NONE, KeyCode::Char('d'))
-                        | (KeyModifiers::NONE, KeyCode::Delete) => {
-                            if let Some(song) = songs.get(local_selected) {
-                                if let Some(path) = &song.file_path {
-                                    confirm_delete = Some(LocalDeleteConfirmation {
-                                        name: song.name.clone(),
-                                        path: path.clone(),
-                                    });
-                                } else {
-                                    ctx.notifications.write().unwrap().push_back(
-                                        Notification::error("无法删除：没有本地文件路径"),
+                            Action::ListSelectFirst => {
+                                local_selected = 0;
+                            }
+                            Action::ListSelectLast => {
+                                local_selected = songs.len().saturating_sub(1);
+                            }
+                            Action::ListPageUp => {
+                                local_selected = local_selected.saturating_sub(10);
+                            }
+                            Action::ListPageDown => {
+                                local_selected =
+                                    (local_selected + 10).min(songs.len().saturating_sub(1));
+                            }
+                            Action::ListAddToQueue => {
+                                if let Some(song) = songs.get(local_selected).cloned() {
+                                    execute_action(
+                                        AppAction::AddToQueue {
+                                            song: Box::new(song),
+                                            position: InsertPosition::End,
+                                        },
+                                        &ctx,
+                                        rt,
+                                        &action_tx,
+                                        &search_page,
+                                        &settings_page,
+                                        &search_seq,
                                     );
                                 }
                             }
+                            Action::ListAddToQueueNext => {
+                                if let Some(song) = songs.get(local_selected).cloned() {
+                                    execute_action(
+                                        AppAction::AddToQueue {
+                                            song: Box::new(song),
+                                            position: InsertPosition::Next,
+                                        },
+                                        &ctx,
+                                        rt,
+                                        &action_tx,
+                                        &search_page,
+                                        &settings_page,
+                                        &search_seq,
+                                    );
+                                }
+                            }
+                            Action::LocalDelete => {
+                                if let Some(song) = songs.get(local_selected) {
+                                    if let Some(path) = &song.file_path {
+                                        confirm_delete = Some(LocalDeleteConfirmation {
+                                            name: song.name.clone(),
+                                            path: path.clone(),
+                                        });
+                                    } else {
+                                        ctx.notifications.write().unwrap().push_back(
+                                            Notification::error("无法删除：没有本地文件路径"),
+                                        );
+                                    }
+                                }
+                            }
+                            Action::ListActivate => {
+                                if !songs.is_empty() && local_selected < songs.len() {
+                                    execute_action(
+                                        AppAction::PlaySong {
+                                            songs,
+                                            index: local_selected,
+                                        },
+                                        &ctx,
+                                        rt,
+                                        &action_tx,
+                                        &search_page,
+                                        &settings_page,
+                                        &search_seq,
+                                    );
+                                }
+                            }
+                            _ => {}
                         }
-                        _ => {}
+                    } else {
+                        match (key.modifiers, key.code) {
+                            (KeyModifiers::NONE, KeyCode::Char('r')) => {
+                                let paths = ctx.config.read().unwrap().local_music.paths.clone();
+                                let max_depth = ctx.config.read().unwrap().local_music.max_depth;
+                                execute_action(
+                                    AppAction::ScanLocalMusic { paths, max_depth },
+                                    &ctx,
+                                    rt,
+                                    &action_tx,
+                                    &search_page,
+                                    &settings_page,
+                                    &search_seq,
+                                );
+                                local_selected = 0;
+                                local_scroll = 0;
+                            }
+                            (KeyModifiers::NONE, KeyCode::Up) => {
+                                local_selected = previous_list_index(
+                                    local_selected,
+                                    songs.len(),
+                                    ctx.config.read().unwrap().ui.wrap_navigation,
+                                );
+                            }
+                            (KeyModifiers::NONE, KeyCode::Down) => {
+                                local_selected = next_list_index(
+                                    local_selected,
+                                    songs.len(),
+                                    ctx.config.read().unwrap().ui.wrap_navigation,
+                                );
+                            }
+                            (KeyModifiers::NONE, KeyCode::Home)
+                            | (KeyModifiers::NONE, KeyCode::Char('g')) => {
+                                local_selected = 0;
+                            }
+                            (KeyModifiers::NONE, KeyCode::End)
+                            | (KeyModifiers::NONE, KeyCode::Char('G'))
+                            | (KeyModifiers::SHIFT, KeyCode::Char('G')) => {
+                                local_selected = songs.len().saturating_sub(1);
+                            }
+                            (KeyModifiers::CONTROL, KeyCode::Char('u'))
+                            | (KeyModifiers::NONE, KeyCode::PageUp) => {
+                                local_selected = local_selected.saturating_sub(10);
+                            }
+                            (KeyModifiers::CONTROL, KeyCode::Char('d'))
+                            | (KeyModifiers::NONE, KeyCode::PageDown) => {
+                                local_selected =
+                                    (local_selected + 10).min(songs.len().saturating_sub(1));
+                            }
+                            _ if pages::is_song_activation_key(&key) => {
+                                if !songs.is_empty() && local_selected < songs.len() {
+                                    execute_action(
+                                        AppAction::PlaySong {
+                                            songs,
+                                            index: local_selected,
+                                        },
+                                        &ctx,
+                                        rt,
+                                        &action_tx,
+                                        &search_page,
+                                        &settings_page,
+                                        &search_seq,
+                                    );
+                                }
+                            }
+                            (KeyModifiers::NONE, KeyCode::Char('a')) => {
+                                if let Some(song) = songs.get(local_selected).cloned() {
+                                    execute_action(
+                                        AppAction::AddToQueue {
+                                            song: Box::new(song),
+                                            position: InsertPosition::End,
+                                        },
+                                        &ctx,
+                                        rt,
+                                        &action_tx,
+                                        &search_page,
+                                        &settings_page,
+                                        &search_seq,
+                                    );
+                                }
+                            }
+                            (KeyModifiers::NONE, KeyCode::Char('A'))
+                            | (KeyModifiers::SHIFT, KeyCode::Char('A')) => {
+                                if let Some(song) = songs.get(local_selected).cloned() {
+                                    execute_action(
+                                        AppAction::AddToQueue {
+                                            song: Box::new(song),
+                                            position: InsertPosition::Next,
+                                        },
+                                        &ctx,
+                                        rt,
+                                        &action_tx,
+                                        &search_page,
+                                        &settings_page,
+                                        &search_seq,
+                                    );
+                                }
+                            }
+                            (KeyModifiers::NONE, KeyCode::Char('d'))
+                            | (KeyModifiers::NONE, KeyCode::Delete) => {
+                                if let Some(song) = songs.get(local_selected) {
+                                    if let Some(path) = &song.file_path {
+                                        confirm_delete = Some(LocalDeleteConfirmation {
+                                            name: song.name.clone(),
+                                            path: path.clone(),
+                                        });
+                                    } else {
+                                        ctx.notifications.write().unwrap().push_back(
+                                            Notification::error("无法删除：没有本地文件路径"),
+                                        );
+                                    }
+                                }
+                            }
+                            _ => {}
+                        }
                     }
                 }
             }
@@ -1355,7 +1474,7 @@ fn run_app(
                         settings_page
                             .lock()
                             .unwrap()
-                            .handle_mouse(mouse, ui_areas.content, &ctx)
+                            .handle_mouse(mouse, ui_areas.content, &ctx, &kb_resolver)
                     }
                     NavTab::LocalMusic => AppAction::None,
                 };

--- a/app/src/pages/bili_login.rs
+++ b/app/src/pages/bili_login.rs
@@ -5,6 +5,7 @@ use std::time::Instant;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use lx_core::events::AppAction;
+use lx_core::keybinding::{Action, KeybindingResolver};
 use lx_source::bili::{BiliQrPoll, BiliQrStatus, BiliSource};
 use qrcode::{Color, QrCode};
 use ratatui::buffer::Buffer;
@@ -222,7 +223,15 @@ impl BiliLoginPage {
         };
     }
 
-    pub fn handle_input(&mut self, key: KeyEvent) -> AppAction {
+    pub fn handle_input(&mut self, key: KeyEvent, resolver: &KeybindingResolver) -> AppAction {
+        if let Some(Action::ListGoBack) = resolver.resolve("bili_login", &key) {
+            if matches!(self.state, BiliLoginState::Success { .. }) {
+                return AppAction::BiliLoginSuccess;
+            } else {
+                return AppAction::GoBack;
+            }
+        }
+
         match (key.modifiers, key.code) {
             (KeyModifiers::NONE, KeyCode::Esc | KeyCode::Backspace)
             | (KeyModifiers::NONE, KeyCode::Char('q')) => {
@@ -417,6 +426,7 @@ mod tests {
 
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use lx_core::events::AppAction;
+    use lx_core::keybinding::KeybindingResolver;
     use lx_source::bili::BiliSource;
     use qrcode::QrCode;
 
@@ -444,7 +454,8 @@ mod tests {
     fn closing_an_error_does_not_report_login_success() {
         let mut page = BiliLoginPage::new(Arc::new(BiliSource::new()));
         page.state = BiliLoginState::Error("network".to_string());
-        let action = page.handle_input(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        let resolver = KeybindingResolver::from_config(&lx_core::keybinding::KeybindingConfig::default());
+        let action = page.handle_input(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE), &resolver);
         assert!(matches!(action, AppAction::GoBack));
     }
 }

--- a/app/src/pages/favorites.rs
+++ b/app/src/pages/favorites.rs
@@ -2,6 +2,7 @@
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use lx_core::events::{AppAction, InsertPosition};
+use lx_core::keybinding::{Action, KeybindingResolver};
 use lx_core::model::song::SongInfo;
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
@@ -34,7 +35,7 @@ impl FavoritesPage {
         self.search_mode
     }
 
-    pub fn handle_input(&mut self, key: &KeyEvent, ctx: &AppContext) -> AppAction {
+    pub fn handle_input(&mut self, key: &KeyEvent, ctx: &AppContext, resolver: &KeybindingResolver) -> AppAction {
         if self.search_mode {
             match (key.modifiers, key.code) {
                 (KeyModifiers::NONE, KeyCode::Esc) => {
@@ -74,6 +75,114 @@ impl FavoritesPage {
         self.clamp_selection(filtered.len());
         let half_page = (self.viewport_height / 2).max(1);
 
+        if let Some(action) = resolver.resolve_page("favorites", key) {
+            match action {
+                Action::FavoritesFilter => {
+                    self.search_mode = true;
+                    return AppAction::None;
+                }
+                Action::ListSelectUp => {
+                    if !filtered.is_empty() {
+                        if self.selected > 0 {
+                            self.selected -= 1;
+                        } else if ctx.config.read().unwrap().ui.wrap_navigation {
+                            self.selected = filtered.len().saturating_sub(1);
+                        }
+                    }
+                    return AppAction::None;
+                }
+                Action::ListSelectDown => {
+                    if !filtered.is_empty() {
+                        if self.selected + 1 < filtered.len() {
+                            self.selected += 1;
+                        } else if ctx.config.read().unwrap().ui.wrap_navigation {
+                            self.selected = 0;
+                        }
+                    }
+                    return AppAction::None;
+                }
+                Action::ListSelectFirst => {
+                    self.selected = 0;
+                    return AppAction::None;
+                }
+                Action::ListSelectLast => {
+                    self.selected = filtered.len().saturating_sub(1);
+                    return AppAction::None;
+                }
+                Action::ListPageUp => {
+                    self.selected = self.selected.saturating_sub(half_page);
+                    return AppAction::None;
+                }
+                Action::ListPageDown => {
+                    self.selected = (self.selected + half_page).min(filtered.len().saturating_sub(1));
+                    return AppAction::None;
+                }
+                Action::ListActivate => {
+                    if self.selected < filtered.len() {
+                        let songs = filtered
+                            .iter()
+                            .filter_map(|index| favorites.get(*index).cloned())
+                            .collect();
+                        return AppAction::PlaySong {
+                            songs,
+                            index: self.selected,
+                        };
+                    }
+                    return AppAction::None;
+                }
+                Action::ListAddToQueue => {
+                    if let Some(song) = filtered
+                        .get(self.selected)
+                        .and_then(|index| favorites.get(*index))
+                        .cloned()
+                    {
+                        return AppAction::AddToQueue {
+                            song: Box::new(song),
+                            position: InsertPosition::End,
+                        };
+                    }
+                    return AppAction::None;
+                }
+                Action::ListAddToQueueNext => {
+                    if let Some(song) = filtered
+                        .get(self.selected)
+                        .and_then(|index| favorites.get(*index))
+                        .cloned()
+                    {
+                        return AppAction::AddToQueue {
+                            song: Box::new(song),
+                            position: InsertPosition::Next,
+                        };
+                    }
+                    return AppAction::None;
+                }
+                Action::FavoritesRemove => {
+                    if let Some(original_index) = filtered.get(self.selected).copied()
+                        && let Some(song) = favorites.get(original_index)
+                        && ctx.storage.remove_favorite(song)
+                    {
+                        let remaining = ctx.storage.load_favorites();
+                        let remaining_len = self.filtered_indices(&remaining).len();
+                        self.clamp_selection(remaining_len);
+                        return AppAction::ShowNotification(lx_core::events::Notification::info(
+                            "已取消收藏",
+                        ));
+                    }
+                    return AppAction::None;
+                }
+                Action::ListGoBack => {
+                    if self.query.is_empty() {
+                        return AppAction::GoBack;
+                    }
+                    self.query.clear();
+                    self.selected = 0;
+                    self.scroll = 0;
+                    return AppAction::None;
+                }
+                _ => {}
+            }
+        }
+
         match (key.modifiers, key.code) {
             (KeyModifiers::NONE, KeyCode::Char('/')) => {
                 self.search_mode = true;
@@ -86,7 +195,7 @@ impl FavoritesPage {
                 self.selected = 0;
                 self.scroll = 0;
             }
-            (KeyModifiers::NONE, KeyCode::Up) | (KeyModifiers::NONE, KeyCode::Char('k')) => {
+            (KeyModifiers::NONE, KeyCode::Up) => {
                 if !filtered.is_empty() {
                     if self.selected > 0 {
                         self.selected -= 1;
@@ -95,7 +204,7 @@ impl FavoritesPage {
                     }
                 }
             }
-            (KeyModifiers::NONE, KeyCode::Down) | (KeyModifiers::NONE, KeyCode::Char('j')) => {
+            (KeyModifiers::NONE, KeyCode::Down) => {
                 if !filtered.is_empty() {
                     if self.selected + 1 < filtered.len() {
                         self.selected += 1;

--- a/app/src/pages/history.rs
+++ b/app/src/pages/history.rs
@@ -2,6 +2,7 @@
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use lx_core::events::{AppAction, InsertPosition};
+use lx_core::keybinding::{Action, KeybindingResolver};
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
@@ -92,11 +93,84 @@ pub fn render(
     }
 }
 
-pub fn handle_input(key: &KeyEvent, ctx: &AppContext, selected: &mut usize) -> AppAction {
+pub fn handle_input(
+    key: &KeyEvent,
+    ctx: &AppContext,
+    selected: &mut usize,
+    resolver: &KeybindingResolver,
+) -> AppAction {
     let history = ctx.storage.load_history();
 
+    if let Some(action) = resolver.resolve_page("history", key) {
+        match action {
+            Action::ListSelectUp => {
+                if !history.is_empty() {
+                    if *selected > 0 {
+                        *selected -= 1;
+                    } else if ctx.config.read().unwrap().ui.wrap_navigation {
+                        *selected = history.len().saturating_sub(1);
+                    }
+                }
+                return AppAction::None;
+            }
+            Action::ListSelectDown => {
+                if !history.is_empty() {
+                    if *selected + 1 < history.len() {
+                        *selected += 1;
+                    } else if ctx.config.read().unwrap().ui.wrap_navigation {
+                        *selected = 0;
+                    }
+                }
+                return AppAction::None;
+            }
+            Action::ListSelectFirst => {
+                *selected = 0;
+                return AppAction::None;
+            }
+            Action::ListSelectLast => {
+                *selected = history.len().saturating_sub(1);
+                return AppAction::None;
+            }
+            Action::ListPageUp => {
+                *selected = selected.saturating_sub(10);
+                return AppAction::None;
+            }
+            Action::ListPageDown => {
+                *selected = (*selected + 10).min(history.len().saturating_sub(1));
+                return AppAction::None;
+            }
+            Action::ListAddToQueue => {
+                if let Some(song) = history.get(*selected).cloned() {
+                    return AppAction::AddToQueue {
+                        song: Box::new(song),
+                        position: InsertPosition::End,
+                    };
+                }
+                return AppAction::None;
+            }
+            Action::ListAddToQueueNext => {
+                if let Some(song) = history.get(*selected).cloned() {
+                    return AppAction::AddToQueue {
+                        song: Box::new(song),
+                        position: InsertPosition::Next,
+                    };
+                }
+                return AppAction::None;
+            }
+            Action::ListActivate => {
+                if !history.is_empty() && *selected < history.len() {
+                    let songs = history.clone();
+                    let index = *selected;
+                    return AppAction::PlaySong { songs, index };
+                }
+                return AppAction::None;
+            }
+            _ => {}
+        }
+    }
+
     match (key.modifiers, key.code) {
-        (KeyModifiers::NONE, KeyCode::Up) | (KeyModifiers::NONE, KeyCode::Char('k')) => {
+        (KeyModifiers::NONE, KeyCode::Up) => {
             if !history.is_empty() {
                 if *selected > 0 {
                     *selected -= 1;
@@ -105,7 +179,7 @@ pub fn handle_input(key: &KeyEvent, ctx: &AppContext, selected: &mut usize) -> A
                 }
             }
         }
-        (KeyModifiers::NONE, KeyCode::Down) | (KeyModifiers::NONE, KeyCode::Char('j')) => {
+        (KeyModifiers::NONE, KeyCode::Down) => {
             if !history.is_empty() {
                 if *selected + 1 < history.len() {
                     *selected += 1;

--- a/app/src/pages/leaderboard.rs
+++ b/app/src/pages/leaderboard.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use lx_core::events::{AppAction, InsertPosition};
+use lx_core::keybinding::{Action, KeybindingResolver};
 use lx_core::model::leaderboard::LeaderboardInfo;
 use lx_core::model::song::SongInfo;
 use lx_core::model::source::SourceId;
@@ -151,7 +152,83 @@ impl LeaderboardPage {
         self.selected = 0;
     }
 
-    pub fn handle_input(&mut self, key: &KeyEvent, ctx: &AppContext) -> AppAction {
+    pub fn handle_input(&mut self, key: &KeyEvent, ctx: &AppContext, resolver: &KeybindingResolver) -> AppAction {
+        if let Some(action) = resolver.resolve_page("leaderboard", key) {
+            match action {
+                Action::ListSelectUp => {
+                    self.move_selection_up(ctx);
+                    return AppAction::None;
+                }
+                Action::ListSelectDown => {
+                    self.move_selection_down(ctx);
+                    return AppAction::None;
+                }
+                Action::ListSelectFirst => {
+                    self.selected = 0;
+                    return AppAction::None;
+                }
+                Action::ListSelectLast => {
+                    self.selected = self.current_list_len().saturating_sub(1);
+                    return AppAction::None;
+                }
+                Action::ListPageUp => {
+                    self.selected = self.selected.saturating_sub(10);
+                    return AppAction::None;
+                }
+                Action::ListPageDown => {
+                    self.selected = (self.selected + 10).min(self.current_list_len().saturating_sub(1));
+                    return AppAction::None;
+                }
+                Action::ListActivate => {
+                    if self.selected_board.is_some() && !self.songs.is_empty() {
+                        return AppAction::PlaySong {
+                            songs: self.songs.clone(),
+                            index: self.selected,
+                        };
+                    }
+                    self.enter_selected_board();
+                    return AppAction::None;
+                }
+                Action::ListAddToQueue => {
+                    if self.selected_board.is_some() {
+                        if let Some(song) = self.songs.get(self.selected).cloned() {
+                            return AppAction::AddToQueue {
+                                song: Box::new(song),
+                                position: InsertPosition::End,
+                            };
+                        }
+                    }
+                    return AppAction::None;
+                }
+                Action::ListAddToQueueNext => {
+                    if self.selected_board.is_some() {
+                        if let Some(song) = self.songs.get(self.selected).cloned() {
+                            return AppAction::AddToQueue {
+                                song: Box::new(song),
+                                position: InsertPosition::Next,
+                            };
+                        }
+                    }
+                    return AppAction::None;
+                }
+                Action::ListGoBack => {
+                    if self.selected_board.is_some() {
+                        self.leave_board();
+                    }
+                    return AppAction::None;
+                }
+                Action::SearchCycleSourcePrev => {
+                    self.select_previous_source();
+                    return AppAction::None;
+                }
+                Action::SearchCycleSourceNext => {
+                    self.select_next_source();
+                    return AppAction::None;
+                }
+                _ => {}
+            }
+        }
+
         match (key.modifiers, key.code) {
             (KeyModifiers::CONTROL, KeyCode::Left)
             | (KeyModifiers::CONTROL, KeyCode::Char('h'))
@@ -165,10 +242,10 @@ impl LeaderboardPage {
             (KeyModifiers::NONE, KeyCode::Right) if self.selected_board.is_none() => {
                 self.select_next_source();
             }
-            (KeyModifiers::NONE, KeyCode::Up) | (KeyModifiers::NONE, KeyCode::Char('k')) => {
+            (KeyModifiers::NONE, KeyCode::Up) => {
                 self.move_selection_up(ctx);
             }
-            (KeyModifiers::NONE, KeyCode::Down) | (KeyModifiers::NONE, KeyCode::Char('j')) => {
+            (KeyModifiers::NONE, KeyCode::Down) => {
                 self.move_selection_down(ctx);
             }
             (KeyModifiers::NONE, KeyCode::Home) | (KeyModifiers::NONE, KeyCode::Char('g')) => {

--- a/app/src/pages/main_page.rs
+++ b/app/src/pages/main_page.rs
@@ -2,6 +2,7 @@
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use lx_core::events::AppAction;
+use lx_core::keybinding::{Action, KeybindingResolver};
 use ratatui::buffer::Buffer;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Modifier, Style};
@@ -50,7 +51,7 @@ impl MainPage {
         }
     }
 
-    pub fn handle_input(&mut self, key: &KeyEvent, ctx: &AppContext) -> AppAction {
+    pub fn handle_input(&mut self, key: &KeyEvent, ctx: &AppContext, resolver: &KeybindingResolver) -> AppAction {
         let (songs, current) = ctx.playlist.snapshot();
         if self.selected >= songs.len() {
             self.selected = current.min(songs.len().saturating_sub(1));
@@ -107,8 +108,65 @@ impl MainPage {
             };
         }
 
+        if let Some(action) = resolver.resolve_page("main", key) {
+            match action {
+                Action::ListSelectUp => {
+                    if !songs.is_empty() {
+                        self.selected = if self.selected == 0 {
+                            if ctx.config.read().unwrap().ui.wrap_navigation {
+                                songs.len() - 1
+                            } else {
+                                0
+                            }
+                        } else {
+                            self.selected - 1
+                        };
+                    }
+                    return AppAction::None;
+                }
+                Action::ListSelectDown => {
+                    if !songs.is_empty() {
+                        self.selected = if self.selected + 1 < songs.len() {
+                            self.selected + 1
+                        } else if ctx.config.read().unwrap().ui.wrap_navigation {
+                            0
+                        } else {
+                            self.selected
+                        };
+                    }
+                    return AppAction::None;
+                }
+                Action::ListSelectFirst => {
+                    self.selected = 0;
+                    return AppAction::None;
+                }
+                Action::ListSelectLast => {
+                    self.selected = songs.len().saturating_sub(1);
+                    return AppAction::None;
+                }
+                Action::ListPageUp => {
+                    self.selected = self.selected.saturating_sub(5);
+                    return AppAction::None;
+                }
+                Action::ListPageDown => {
+                    self.selected = (self.selected + 5).min(songs.len().saturating_sub(1));
+                    return AppAction::None;
+                }
+                Action::ListActivate => {
+                    if self.selected < songs.len() {
+                        return AppAction::PlaySong {
+                            songs,
+                            index: self.selected,
+                        };
+                    }
+                    return AppAction::None;
+                }
+                _ => {}
+            }
+        }
+
         match (key.modifiers, key.code) {
-            (KeyModifiers::NONE, KeyCode::Up) | (KeyModifiers::NONE, KeyCode::Char('k')) => {
+            (KeyModifiers::NONE, KeyCode::Up) => {
                 if !songs.is_empty() {
                     self.selected = if self.selected == 0 {
                         if ctx.config.read().unwrap().ui.wrap_navigation {
@@ -121,7 +179,7 @@ impl MainPage {
                     };
                 }
             }
-            (KeyModifiers::NONE, KeyCode::Down) | (KeyModifiers::NONE, KeyCode::Char('j')) => {
+            (KeyModifiers::NONE, KeyCode::Down) => {
                 if !songs.is_empty() {
                     self.selected = if self.selected + 1 < songs.len() {
                         self.selected + 1

--- a/app/src/pages/playlists.rs
+++ b/app/src/pages/playlists.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use lx_core::events::{AppAction, InsertPosition, Notification};
+use lx_core::keybinding::{Action, KeybindingResolver};
 use lx_core::model::playlist::Playlist;
 use lx_core::model::song::SongInfo;
 use lx_core::model::source::SourceId;
@@ -177,7 +178,83 @@ impl PlaylistsPage {
         self.selected = 0;
     }
 
-    pub fn handle_input(&mut self, key: &KeyEvent, ctx: &AppContext) -> AppAction {
+    pub fn handle_input(&mut self, key: &KeyEvent, ctx: &AppContext, resolver: &KeybindingResolver) -> AppAction {
+        if let Some(action) = resolver.resolve_page("playlists", key) {
+            match action {
+                Action::ListSelectUp => {
+                    self.move_selection_up(ctx);
+                    return AppAction::None;
+                }
+                Action::ListSelectDown => {
+                    self.move_selection_down(ctx);
+                    return AppAction::None;
+                }
+                Action::ListSelectFirst => {
+                    self.selected = 0;
+                    return AppAction::None;
+                }
+                Action::ListSelectLast => {
+                    self.selected = self.current_list_len().saturating_sub(1);
+                    return AppAction::None;
+                }
+                Action::ListPageUp => {
+                    self.selected = self.selected.saturating_sub(10);
+                    return AppAction::None;
+                }
+                Action::ListPageDown => {
+                    self.selected = (self.selected + 10).min(self.current_list_len().saturating_sub(1));
+                    return AppAction::None;
+                }
+                Action::ListActivate => {
+                    if self.selected_playlist.is_some() && !self.songs.is_empty() {
+                        return AppAction::PlaySong {
+                            songs: self.songs.clone(),
+                            index: self.selected,
+                        };
+                    }
+                    self.enter_selected_playlist();
+                    return AppAction::None;
+                }
+                Action::ListAddToQueue => {
+                    if self.selected_playlist.is_some() {
+                        if let Some(song) = self.songs.get(self.selected).cloned() {
+                            return AppAction::AddToQueue {
+                                song: Box::new(song),
+                                position: InsertPosition::End,
+                            };
+                        }
+                    }
+                    return AppAction::None;
+                }
+                Action::ListAddToQueueNext => {
+                    if self.selected_playlist.is_some() {
+                        if let Some(song) = self.songs.get(self.selected).cloned() {
+                            return AppAction::AddToQueue {
+                                song: Box::new(song),
+                                position: InsertPosition::Next,
+                            };
+                        }
+                    }
+                    return AppAction::None;
+                }
+                Action::ListGoBack => {
+                    if self.selected_playlist.is_some() {
+                        self.leave_playlist();
+                    }
+                    return AppAction::None;
+                }
+                Action::SearchCycleSourcePrev => {
+                    self.select_previous_scope(ctx);
+                    return AppAction::None;
+                }
+                Action::SearchCycleSourceNext => {
+                    self.select_next_scope(ctx);
+                    return AppAction::None;
+                }
+                _ => {}
+            }
+        }
+
         match (key.modifiers, key.code) {
             (KeyModifiers::CONTROL, KeyCode::Left)
             | (KeyModifiers::CONTROL, KeyCode::Char('h'))
@@ -191,10 +268,10 @@ impl PlaylistsPage {
             (KeyModifiers::NONE, KeyCode::Right) if self.selected_playlist.is_none() => {
                 self.select_next_scope(ctx);
             }
-            (KeyModifiers::NONE, KeyCode::Up) | (KeyModifiers::NONE, KeyCode::Char('k')) => {
+            (KeyModifiers::NONE, KeyCode::Up) => {
                 self.move_selection_up(ctx);
             }
-            (KeyModifiers::NONE, KeyCode::Down) | (KeyModifiers::NONE, KeyCode::Char('j')) => {
+            (KeyModifiers::NONE, KeyCode::Down) => {
                 self.move_selection_down(ctx);
             }
             (KeyModifiers::NONE, KeyCode::Home) | (KeyModifiers::NONE, KeyCode::Char('g')) => {

--- a/app/src/pages/search.rs
+++ b/app/src/pages/search.rs
@@ -2,6 +2,7 @@
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use lx_core::events::{AppAction, InsertPosition};
+use lx_core::keybinding::{Action, KeybindingResolver};
 use lx_core::model::song::SongInfo;
 use lx_core::model::source::SourceId;
 use lx_core::traits::source::SearchResult;
@@ -75,7 +76,7 @@ impl SearchPage {
         }
     }
 
-    pub fn handle_input(&mut self, key: KeyEvent) -> AppAction {
+    pub fn handle_input(&mut self, key: KeyEvent, resolver: &KeybindingResolver) -> AppAction {
         if !self.variant_indices.is_empty() {
             return self.handle_variant_input(key);
         }
@@ -124,6 +125,119 @@ impl SearchPage {
                         self.selected = 0;
                         self.scroll_offset = 0;
                     }
+                }
+                _ => {}
+            }
+            return AppAction::None;
+        }
+
+        if let Some(action) = resolver.resolve("search", &key) {
+            match action {
+                Action::SearchInputMode => {
+                    self.input_mode = true;
+                }
+                Action::SearchStart => {
+                    let keyword = self.input.trim().to_string();
+                    if keyword.is_empty() {
+                        return AppAction::None;
+                    }
+                    if self.is_searching && self.last_searched_input == keyword {
+                        return AppAction::None;
+                    }
+                    if self.result_keyword == keyword && !self.results.is_empty() {
+                        let songs = self.results.clone();
+                        let index = self.selected;
+                        return AppAction::PlaySong { songs, index };
+                    }
+                    self.last_input_time = std::time::Instant::now();
+                    self.last_searched_input = keyword.clone();
+                    return AppAction::Search {
+                        keyword,
+                        source: self.source_filter,
+                    };
+                }
+                Action::SearchToggleAggregate => {
+                    self.open_variants();
+                }
+                Action::ListAddToQueue => {
+                    if let Some(song) = self.results.get(self.selected).cloned() {
+                        return AppAction::AddToQueue {
+                            song: Box::new(song),
+                            position: InsertPosition::End,
+                        };
+                    }
+                }
+                Action::ListAddToQueueNext => {
+                    if let Some(song) = self.results.get(self.selected).cloned() {
+                        return AppAction::AddToQueue {
+                            song: Box::new(song),
+                            position: InsertPosition::Next,
+                        };
+                    }
+                }
+                Action::ListActivate => {
+                    if !self.results.is_empty() {
+                        return AppAction::PlaySong {
+                            songs: self.results.clone(),
+                            index: self.selected,
+                        };
+                    }
+                }
+                Action::ListSelectUp => {
+                    if !self.results.is_empty() {
+                        if self.selected > 0 {
+                            self.selected -= 1;
+                        } else if self.wrap_navigation {
+                            self.selected = self.results.len().saturating_sub(1);
+                        }
+                    }
+                }
+                Action::ListSelectDown => {
+                    if !self.results.is_empty() {
+                        if self.selected + 1 < self.results.len() {
+                            self.selected += 1;
+                        } else if self.can_load_more() {
+                            return AppAction::SearchMore {
+                                keyword: self.result_keyword.clone(),
+                                page: self.current_page + 1,
+                                source: self.source_filter,
+                            };
+                        } else if self.wrap_navigation {
+                            self.selected = 0;
+                        }
+                    }
+                }
+                Action::ListSelectFirst => {
+                    self.selected = 0;
+                }
+                Action::ListSelectLast => {
+                    self.selected = self.results.len().saturating_sub(1);
+                }
+                Action::ListPageUp => {
+                    if !self.results.is_empty() {
+                        self.selected = self.selected.saturating_sub(10);
+                    }
+                }
+                Action::ListPageDown => {
+                    if !self.results.is_empty() {
+                        self.selected = (self.selected + 10).min(self.results.len().saturating_sub(1));
+                        if self.selected + 1 == self.results.len() && self.can_load_more() {
+                            return AppAction::SearchMore {
+                                keyword: self.result_keyword.clone(),
+                                page: self.current_page + 1,
+                                source: self.source_filter,
+                            };
+                        }
+                    }
+                }
+                Action::SearchCycleSourcePrev => {
+                    return self.cycle_source(-1);
+                }
+                Action::SearchCycleSourceNext => {
+                    return self.cycle_source(1);
+                }
+                Action::ListGoBack => {
+                    return AppAction::GoBack;
                 }
                 _ => {}
             }
@@ -186,7 +300,7 @@ impl SearchPage {
                     source: self.source_filter,
                 };
             }
-            (KeyModifiers::NONE, KeyCode::Up) | (KeyModifiers::NONE, KeyCode::Char('k')) => {
+            (KeyModifiers::NONE, KeyCode::Up) => {
                 if !self.results.is_empty() {
                     if self.selected > 0 {
                         self.selected -= 1;
@@ -195,7 +309,7 @@ impl SearchPage {
                     }
                 }
             }
-            (KeyModifiers::NONE, KeyCode::Down) | (KeyModifiers::NONE, KeyCode::Char('j')) => {
+            (KeyModifiers::NONE, KeyCode::Down) => {
                 if !self.results.is_empty() {
                     if self.selected + 1 < self.results.len() {
                         self.selected += 1;
@@ -644,8 +758,7 @@ impl SearchPage {
                 self.close_variants();
             }
             (KeyModifiers::NONE, KeyCode::Up)
-            | (KeyModifiers::NONE, KeyCode::Left)
-            | (KeyModifiers::NONE, KeyCode::Char('k')) => {
+            | (KeyModifiers::NONE, KeyCode::Left) => {
                 if self.variant_selected > 0 {
                     self.variant_selected -= 1;
                 } else if self.wrap_navigation {
@@ -653,8 +766,7 @@ impl SearchPage {
                 }
             }
             (KeyModifiers::NONE, KeyCode::Down)
-            | (KeyModifiers::NONE, KeyCode::Right)
-            | (KeyModifiers::NONE, KeyCode::Char('j')) => {
+            | (KeyModifiers::NONE, KeyCode::Right) => {
                 if self.variant_selected + 1 < self.variant_indices.len() {
                     self.variant_selected += 1;
                 } else if self.wrap_navigation {
@@ -874,6 +986,7 @@ mod tests {
     use super::{SearchPage, matching_variant_indices};
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use lx_core::events::AppAction;
+    use lx_core::keybinding::KeybindingResolver;
     use lx_core::model::song::SongInfo;
     use lx_core::model::source::SourceId;
 
@@ -885,8 +998,9 @@ mod tests {
     fn right_arrow_cycles_search_scope() {
         let mut page = SearchPage::new(None, true, 3);
         page.input_mode = false;
+        let resolver = KeybindingResolver::from_config(&lx_core::keybinding::KeybindingConfig::default());
 
-        let action = page.handle_input(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE));
+        let action = page.handle_input(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE), &resolver);
 
         assert_eq!(page.source_filter, Some(SourceId::Kw));
         assert!(matches!(action, AppAction::None));
@@ -897,8 +1011,9 @@ mod tests {
         let mut page = SearchPage::new(None, true, 3);
         page.input_mode = false;
         page.results = vec![song("kw-1", SourceId::Kw, "晴天", "周杰伦")];
+        let resolver = KeybindingResolver::from_config(&lx_core::keybinding::KeybindingConfig::default());
 
-        let action = page.handle_input(KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE));
+        let action = page.handle_input(KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE), &resolver);
 
         assert!(matches!(action, AppAction::PlaySong { index: 0, .. }));
     }

--- a/app/src/pages/settings.rs
+++ b/app/src/pages/settings.rs
@@ -2,6 +2,7 @@
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use lx_core::events::AppAction;
+use lx_core::keybinding::{Action, KeybindingResolver};
 use ratatui::buffer::Buffer;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
@@ -68,7 +69,7 @@ impl SettingsPage {
         }
     }
 
-    pub fn handle_input(&mut self, key: KeyEvent, ctx: &AppContext) -> AppAction {
+    pub fn handle_input(&mut self, key: KeyEvent, ctx: &AppContext, resolver: &KeybindingResolver) -> AppAction {
         if self.local_path_mode {
             return self.handle_local_path_input(key, ctx);
         }
@@ -100,21 +101,40 @@ impl SettingsPage {
         } else {
             // 先判断焦点区域：local 区域的按键优先处理
             if self.focus == "local" {
-                return self.handle_local_keys(key, ctx);
+                return self.handle_local_keys(key, ctx, resolver);
             }
 
             let sources = ctx.config.read().unwrap().source.js_sources.clone();
+
+            if let Some(action) = resolver.resolve_page("settings", &key) {
+                match action {
+                    Action::ListSelectUp => {
+                        if self.selected_source > 0 {
+                            self.selected_source -= 1;
+                        }
+                        return AppAction::None;
+                    }
+                    Action::ListSelectDown => {
+                        if self.selected_source + 1 < sources.len() {
+                            self.selected_source += 1;
+                        }
+                        return AppAction::None;
+                    }
+                    _ => {}
+                }
+            }
+
             match (key.modifiers, key.code) {
                 (KeyModifiers::NONE, KeyCode::Char('a')) => {
                     self.input_mode = true;
                     self.status_msg = None;
                 }
-                (KeyModifiers::NONE, KeyCode::Up) | (KeyModifiers::NONE, KeyCode::Char('k')) => {
+                (KeyModifiers::NONE, KeyCode::Up) => {
                     if self.selected_source > 0 {
                         self.selected_source -= 1;
                     }
                 }
-                (KeyModifiers::NONE, KeyCode::Down) | (KeyModifiers::NONE, KeyCode::Char('j')) => {
+                (KeyModifiers::NONE, KeyCode::Down) => {
                     if self.selected_source + 1 < sources.len() {
                         self.selected_source += 1;
                     }
@@ -242,8 +262,27 @@ impl SettingsPage {
     }
 
     /// 处理本地音乐区域的按键（非输入模式）
-    fn handle_local_keys(&mut self, key: KeyEvent, ctx: &AppContext) -> AppAction {
+    fn handle_local_keys(&mut self, key: KeyEvent, ctx: &AppContext, resolver: &KeybindingResolver) -> AppAction {
         let paths = ctx.config.read().unwrap().local_music.paths.clone();
+
+        if let Some(action) = resolver.resolve_page("settings", &key) {
+            match action {
+                Action::ListSelectUp => {
+                    if self.selected_local_path > 0 {
+                        self.selected_local_path -= 1;
+                    }
+                    return AppAction::None;
+                }
+                Action::ListSelectDown => {
+                    if self.selected_local_path + 1 < paths.len() {
+                        self.selected_local_path += 1;
+                    }
+                    return AppAction::None;
+                }
+                _ => {}
+            }
+        }
+
         match (key.modifiers, key.code) {
             (KeyModifiers::NONE, KeyCode::Char('s')) => {
                 self.focus = "js".to_string();
@@ -255,13 +294,13 @@ impl SettingsPage {
                 self.status_msg = None;
                 AppAction::None
             }
-            (KeyModifiers::NONE, KeyCode::Up) | (KeyModifiers::NONE, KeyCode::Char('k')) => {
+            (KeyModifiers::NONE, KeyCode::Up) => {
                 if self.selected_local_path > 0 {
                     self.selected_local_path -= 1;
                 }
                 AppAction::None
             }
-            (KeyModifiers::NONE, KeyCode::Down) | (KeyModifiers::NONE, KeyCode::Char('j')) => {
+            (KeyModifiers::NONE, KeyCode::Down) => {
                 if self.selected_local_path + 1 < paths.len() {
                     self.selected_local_path += 1;
                 }
@@ -595,7 +634,7 @@ impl SettingsPage {
         }
     }
 
-    pub fn handle_mouse(&mut self, event: MouseEvent, area: Rect, ctx: &AppContext) -> AppAction {
+    pub fn handle_mouse(&mut self, event: MouseEvent, area: Rect, ctx: &AppContext, resolver: &KeybindingResolver) -> AppAction {
         if self.input_mode {
             return AppAction::None;
         }
@@ -625,6 +664,7 @@ impl SettingsPage {
                         return self.handle_input(
                             KeyEvent::new(KeyCode::Char(key), KeyModifiers::NONE),
                             ctx,
+                            resolver,
                         );
                     }
                 }

--- a/core/src/keybinding/mod.rs
+++ b/core/src/keybinding/mod.rs
@@ -1,0 +1,537 @@
+//! 自定义键位映射系统（Phase 1）
+//!
+//! 设计目标：
+//! - 单键映射，零学习成本
+//! - 全局 + 页面级两层作用域
+//! - 完全兼容现有硬编码行为（默认配置 = 当前键位）
+//! - 可扩展至多键序列（Phase 2）
+
+use std::collections::HashMap;
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use serde::{Deserialize, Serialize};
+
+// =============================================================================
+// Action 枚举：所有可绑定的动作
+// =============================================================================
+
+/// 可绑定的用户动作。
+///
+/// 命名约定：`<domain>_<verb>`，如 `global_quit`、`search_select_down`。
+/// 这样即使不同页面有同名动作（如上下导航），也可以通过域名区分。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Action {
+    // --- 全局动作 ---
+    /// 退出应用
+    GlobalQuit,
+    /// 播放/暂停
+    GlobalPlayPause,
+    /// 下一首
+    GlobalNextTrack,
+    /// 上一首
+    GlobalPrevTrack,
+    /// 切换播放模式（列表循环 / 单曲循环 / 随机）
+    GlobalCycleMode,
+    /// 快进 5 秒
+    GlobalSeekForward,
+    /// 后退 5 秒
+    GlobalSeekBackward,
+    /// 音量增加
+    GlobalVolumeUp,
+    /// 音量减少
+    GlobalVolumeDown,
+    /// 下一个标签页
+    GlobalNextTab,
+    /// 上一个标签页
+    GlobalPrevTab,
+    /// 返回主页面（Esc）
+    GlobalGoToMain,
+    /// 收藏/取消收藏当前歌曲（Ctrl+L）
+    GlobalToggleFavorite,
+
+    // --- 通用列表动作（多个页面共用） ---
+    /// 选择上一项
+    ListSelectUp,
+    /// 选择下一项
+    ListSelectDown,
+    /// 跳到第一项
+    ListSelectFirst,
+    /// 跳到最后一项
+    ListSelectLast,
+    /// 向上翻页
+    ListPageUp,
+    /// 向下翻页
+    ListPageDown,
+    /// 激活选中项（播放 / 进入）
+    ListActivate,
+    /// 返回/退出（Esc）
+    ListGoBack,
+    /// 添加到队列尾部
+    ListAddToQueue,
+    /// 添加到队列下一首
+    ListAddToQueueNext,
+
+    // --- 搜索页面专用 ---
+    /// 进入搜索输入模式
+    SearchInputMode,
+    /// 开始搜索 / 播放结果（Enter 的复合语义）
+    SearchStart,
+    /// 切换聚合/单音源搜索
+    SearchToggleAggregate,
+    /// 切换上一个音源
+    SearchCycleSourcePrev,
+    /// 切换下一个音源
+    SearchCycleSourceNext,
+
+    // --- 本地音乐页面专用 ---
+    /// 重新扫描本地音乐目录
+    LocalRescan,
+    /// 删除选中的本地文件（弹出确认）
+    LocalDelete,
+
+    // --- 收藏页面专用 ---
+    /// 进入过滤模式
+    FavoritesFilter,
+    /// 取消收藏
+    FavoritesRemove,
+
+    // --- 设置页面专用 ---
+    /// 切换设置项的值
+    SettingsToggle,
+}
+
+// =============================================================================
+// KeybindingConfig：序列化配置结构
+// =============================================================================
+
+/// 键位配置根结构。
+///
+/// TOML 示例：
+/// ```toml
+/// [keybindings.global]
+/// quit = "q"
+/// play_pause = "Space"
+/// next_track = "n"
+/// prev_track = "b"
+///
+/// [keybindings.pages.search]
+/// select_up = "k"
+/// select_down = "j"
+/// ```
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct KeybindingConfig {
+    /// 全局键位映射：动作 -> 键位字符串
+    #[serde(default = "default_global_bindings")]
+    pub global: HashMap<Action, String>,
+    /// 页面级键位映射：页面名 -> (动作 -> 键位字符串)
+    #[serde(default = "default_page_bindings")]
+    pub pages: HashMap<String, HashMap<Action, String>>,
+}
+
+/// 默认全局键位（与现有硬编码完全一致）
+fn default_global_bindings() -> HashMap<Action, String> {
+    let mut m = HashMap::new();
+    m.insert(Action::GlobalQuit, "q".to_string());
+    m.insert(Action::GlobalPlayPause, "Space".to_string());
+    m.insert(Action::GlobalNextTrack, "n".to_string());
+    m.insert(Action::GlobalPrevTrack, "b".to_string());
+    m.insert(Action::GlobalCycleMode, "m".to_string());
+    m.insert(Action::GlobalSeekForward, "]".to_string());
+    m.insert(Action::GlobalSeekBackward, "[".to_string());
+    m.insert(Action::GlobalVolumeUp, ".".to_string());
+    m.insert(Action::GlobalVolumeDown, ",".to_string());
+    m.insert(Action::GlobalNextTab, "Tab".to_string());
+    m.insert(Action::GlobalPrevTab, "Shift+Tab".to_string());
+    m.insert(Action::GlobalGoToMain, "Esc".to_string());
+    m.insert(Action::GlobalToggleFavorite, "Ctrl+l".to_string());
+    m
+}
+
+/// 默认页面级键位（与现有硬编码完全一致）
+fn default_page_bindings() -> HashMap<String, HashMap<Action, String>> {
+    let mut pages = HashMap::new();
+
+    // --- 搜索页面 ---
+    let mut search = HashMap::new();
+    search.insert(Action::SearchInputMode, "i".to_string());
+    search.insert(Action::SearchStart, "Enter".to_string());
+    search.insert(Action::SearchToggleAggregate, "v".to_string());
+    search.insert(Action::ListSelectUp, "k".to_string());
+    search.insert(Action::ListSelectDown, "j".to_string());
+    search.insert(Action::ListSelectFirst, "g".to_string());
+    search.insert(Action::ListSelectLast, "G".to_string());
+    search.insert(Action::ListPageUp, "Ctrl+u".to_string());
+    search.insert(Action::ListPageDown, "Ctrl+d".to_string());
+    search.insert(Action::ListActivate, "l".to_string());
+    search.insert(Action::ListAddToQueue, "a".to_string());
+    search.insert(Action::ListAddToQueueNext, "A".to_string());
+    search.insert(Action::SearchCycleSourcePrev, "Left".to_string());
+    search.insert(Action::SearchCycleSourceNext, "Right".to_string());
+    search.insert(Action::ListGoBack, "Esc".to_string());
+    pages.insert("search".to_string(), search);
+
+    // --- 主页（队列） ---
+    let mut main = HashMap::new();
+    main.insert(Action::ListSelectUp, "k".to_string());
+    main.insert(Action::ListSelectDown, "j".to_string());
+    main.insert(Action::ListSelectFirst, "g".to_string());
+    main.insert(Action::ListSelectLast, "G".to_string());
+    main.insert(Action::ListPageUp, "Ctrl+u".to_string());
+    main.insert(Action::ListPageDown, "Ctrl+d".to_string());
+    main.insert(Action::ListActivate, "Enter".to_string());
+    pages.insert("main".to_string(), main);
+
+    // --- 排行榜 ---
+    let mut leaderboard = HashMap::new();
+    leaderboard.insert(Action::ListSelectUp, "k".to_string());
+    leaderboard.insert(Action::ListSelectDown, "j".to_string());
+    leaderboard.insert(Action::ListSelectFirst, "g".to_string());
+    leaderboard.insert(Action::ListSelectLast, "G".to_string());
+    leaderboard.insert(Action::ListPageUp, "Ctrl+u".to_string());
+    leaderboard.insert(Action::ListPageDown, "Ctrl+d".to_string());
+    leaderboard.insert(Action::ListActivate, "Enter".to_string());
+    leaderboard.insert(Action::ListAddToQueue, "a".to_string());
+    leaderboard.insert(Action::ListAddToQueueNext, "A".to_string());
+    leaderboard.insert(Action::SearchCycleSourcePrev, "Left".to_string());
+    leaderboard.insert(Action::SearchCycleSourceNext, "Right".to_string());
+    leaderboard.insert(Action::ListGoBack, "Esc".to_string());
+    pages.insert("leaderboard".to_string(), leaderboard);
+
+    // --- 歌单 ---
+    let mut playlists = HashMap::new();
+    playlists.insert(Action::ListSelectUp, "k".to_string());
+    playlists.insert(Action::ListSelectDown, "j".to_string());
+    playlists.insert(Action::ListSelectFirst, "g".to_string());
+    playlists.insert(Action::ListSelectLast, "G".to_string());
+    playlists.insert(Action::ListPageUp, "Ctrl+u".to_string());
+    playlists.insert(Action::ListPageDown, "Ctrl+d".to_string());
+    playlists.insert(Action::ListActivate, "Enter".to_string());
+    playlists.insert(Action::ListAddToQueue, "a".to_string());
+    playlists.insert(Action::ListAddToQueueNext, "A".to_string());
+    playlists.insert(Action::SearchCycleSourcePrev, "Left".to_string());
+    playlists.insert(Action::SearchCycleSourceNext, "Right".to_string());
+    playlists.insert(Action::ListGoBack, "Esc".to_string());
+    pages.insert("playlists".to_string(), playlists);
+
+    // --- 收藏 ---
+    let mut favorites = HashMap::new();
+    favorites.insert(Action::FavoritesFilter, "/".to_string());
+    favorites.insert(Action::ListSelectUp, "k".to_string());
+    favorites.insert(Action::ListSelectDown, "j".to_string());
+    favorites.insert(Action::ListSelectFirst, "g".to_string());
+    favorites.insert(Action::ListSelectLast, "G".to_string());
+    favorites.insert(Action::ListPageUp, "Ctrl+u".to_string());
+    favorites.insert(Action::ListPageDown, "Ctrl+d".to_string());
+    favorites.insert(Action::ListActivate, "Enter".to_string());
+    favorites.insert(Action::ListAddToQueue, "a".to_string());
+    favorites.insert(Action::ListAddToQueueNext, "A".to_string());
+    favorites.insert(Action::FavoritesRemove, "d".to_string());
+    favorites.insert(Action::ListGoBack, "Esc".to_string());
+    pages.insert("favorites".to_string(), favorites);
+
+    // --- 历史 ---
+    let mut history = HashMap::new();
+    history.insert(Action::ListSelectUp, "k".to_string());
+    history.insert(Action::ListSelectDown, "j".to_string());
+    history.insert(Action::ListSelectFirst, "g".to_string());
+    history.insert(Action::ListSelectLast, "G".to_string());
+    history.insert(Action::ListPageUp, "Ctrl+u".to_string());
+    history.insert(Action::ListPageDown, "Ctrl+d".to_string());
+    history.insert(Action::ListActivate, "Enter".to_string());
+    history.insert(Action::ListAddToQueue, "a".to_string());
+    history.insert(Action::ListAddToQueueNext, "A".to_string());
+    pages.insert("history".to_string(), history);
+
+    // --- 本地音乐 ---
+    let mut local = HashMap::new();
+    local.insert(Action::ListSelectUp, "k".to_string());
+    local.insert(Action::ListSelectDown, "j".to_string());
+    local.insert(Action::ListSelectFirst, "g".to_string());
+    local.insert(Action::ListSelectLast, "G".to_string());
+    local.insert(Action::ListPageUp, "Ctrl+u".to_string());
+    local.insert(Action::ListPageDown, "Ctrl+d".to_string());
+    local.insert(Action::ListActivate, "Enter".to_string());
+    local.insert(Action::ListAddToQueue, "a".to_string());
+    local.insert(Action::ListAddToQueueNext, "A".to_string());
+    local.insert(Action::LocalRescan, "r".to_string());
+    local.insert(Action::LocalDelete, "d".to_string());
+    pages.insert("local".to_string(), local);
+
+    // --- 设置 ---
+    let mut settings = HashMap::new();
+    settings.insert(Action::ListSelectUp, "k".to_string());
+    settings.insert(Action::ListSelectDown, "j".to_string());
+    settings.insert(Action::ListGoBack, "Esc".to_string());
+    pages.insert("settings".to_string(), settings);
+
+    // --- B站登录 ---
+    let mut bili_login = HashMap::new();
+    bili_login.insert(Action::ListGoBack, "Esc".to_string());
+    pages.insert("bili_login".to_string(), bili_login);
+
+    pages
+}
+
+// =============================================================================
+// KeyBinding：运行时解析后的键位表示
+// =============================================================================
+
+/// 解析后的键位，可直接与 `KeyEvent` 匹配。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct KeyBinding {
+    pub modifiers: KeyModifiers,
+    pub code: KeyCode,
+}
+
+impl KeyBinding {
+    /// 从 `KeyEvent` 创建
+    pub fn from_event(event: KeyEvent) -> Self {
+        Self {
+            modifiers: event.modifiers,
+            code: event.code,
+        }
+    }
+
+    /// 匹配一个 `KeyEvent`（忽略 kind 和 state）
+    pub fn matches(&self, event: &KeyEvent) -> bool {
+        self.code == event.code && self.modifiers == event.modifiers
+    }
+}
+
+// =============================================================================
+// 解析器：字符串 -> KeyBinding
+// =============================================================================
+
+/// 解析键位描述字符串，如 `"Ctrl+l"`、`"Space"`、`"Shift+Tab"`。
+///
+/// 支持的修饰符前缀：`Ctrl+`, `Shift+`, `Alt+`, `Ctrl+Shift+` 等组合。
+/// 支持的特殊键名：
+/// - `Space`, `Tab`, `BackTab`, `Enter`, `Esc`, `Backspace`
+/// - `Up`, `Down`, `Left`, `Right`
+/// - `Home`, `End`, `PageUp`, `PageDown`
+/// - `Insert`, `Delete`
+/// - `F1` ~ `F12`
+pub fn parse_keybinding(desc: &str) -> Option<KeyBinding> {
+    let desc = desc.trim();
+    if desc.is_empty() {
+        return None;
+    }
+
+    // 解析修饰符
+    let mut modifiers = KeyModifiers::NONE;
+    let mut remaining = desc;
+
+    loop {
+        if let Some(rest) = remaining.strip_prefix("Ctrl+") {
+            modifiers |= KeyModifiers::CONTROL;
+            remaining = rest;
+        } else if let Some(rest) = remaining.strip_prefix("Shift+") {
+            modifiers |= KeyModifiers::SHIFT;
+            remaining = rest;
+        } else if let Some(_rest) = remaining.strip_prefix("Alt+") {
+            modifiers |= KeyModifiers::ALT;
+            remaining = _rest;
+        } else {
+            break;
+        }
+    }
+
+    // 特殊处理：Shift+Tab 在 crossterm 中报告为 BackTab + SHIFT
+    if modifiers == KeyModifiers::SHIFT && remaining == "Tab" {
+        return Some(KeyBinding {
+            modifiers: KeyModifiers::SHIFT,
+            code: KeyCode::BackTab,
+        });
+    }
+
+    // 解析键码
+    let code = parse_keycode(remaining)?;
+
+    Some(KeyBinding { modifiers, code })
+}
+
+fn parse_keycode(s: &str) -> Option<KeyCode> {
+    match s {
+        "Space" | " " => Some(KeyCode::Char(' ')),
+        "Tab" => Some(KeyCode::Tab),
+        "BackTab" => Some(KeyCode::BackTab),
+        "Enter" | "Return" => Some(KeyCode::Enter),
+        "Esc" | "Escape" => Some(KeyCode::Esc),
+        "Backspace" => Some(KeyCode::Backspace),
+        "Up" => Some(KeyCode::Up),
+        "Down" => Some(KeyCode::Down),
+        "Left" => Some(KeyCode::Left),
+        "Right" => Some(KeyCode::Right),
+        "Home" => Some(KeyCode::Home),
+        "End" => Some(KeyCode::End),
+        "PageUp" => Some(KeyCode::PageUp),
+        "PageDown" => Some(KeyCode::PageDown),
+        "Insert" => Some(KeyCode::Insert),
+        "Delete" => Some(KeyCode::Delete),
+        "CapsLock" => Some(KeyCode::CapsLock),
+        "Null" => Some(KeyCode::Null),
+        _ => {
+            // 尝试解析 F1-F12
+            if s.len() >= 2 && s.starts_with('F') {
+                if let Ok(n) = s[1..].parse::<u8>() {
+                    if (1..=12).contains(&n) {
+                        return Some(KeyCode::F(n));
+                    }
+                }
+            }
+            // 尝试解析单个字符
+            if s.len() == 1 {
+                let c = s.chars().next().unwrap();
+                return Some(KeyCode::Char(c));
+            }
+            None
+        }
+    }
+}
+
+// =============================================================================
+// KeybindingResolver：运行时快速查表
+// =============================================================================
+
+/// 运行时键位解析器。
+///
+/// 把配置中的字符串键位预解析为 `HashMap<KeyBinding, Action>`，
+/// 实现 O(1) 的事件到动作查找。
+pub struct KeybindingResolver {
+    global: HashMap<KeyBinding, Action>,
+    pages: HashMap<String, HashMap<KeyBinding, Action>>,
+}
+
+impl KeybindingResolver {
+    /// 从配置创建解析器
+    pub fn from_config(config: &KeybindingConfig) -> Self {
+        let mut global = HashMap::new();
+        for (action, key_str) in &config.global {
+            if let Some(binding) = parse_keybinding(key_str) {
+                global.insert(binding, *action);
+            }
+        }
+
+        let mut pages = HashMap::new();
+        for (page_name, page_bindings) in &config.pages {
+            let mut page_map = HashMap::new();
+            for (action, key_str) in page_bindings {
+                if let Some(binding) = parse_keybinding(key_str) {
+                    page_map.insert(binding, *action);
+                }
+            }
+            pages.insert(page_name.clone(), page_map);
+        }
+
+        Self { global, pages }
+    }
+
+    /// 解析全局键位事件
+    pub fn resolve_global(&self, event: &KeyEvent) -> Option<Action> {
+        let binding = KeyBinding::from_event(*event);
+        self.global.get(&binding).copied()
+    }
+
+    /// 解析页面级键位事件
+    pub fn resolve_page(&self, page: &str, event: &KeyEvent) -> Option<Action> {
+        let binding = KeyBinding::from_event(*event);
+        self.pages
+            .get(page)
+            .and_then(|map| map.get(&binding).copied())
+    }
+
+    /// 同时查询全局和页面级（页面级优先）
+    pub fn resolve(&self, page: &str, event: &KeyEvent) -> Option<Action> {
+        self.resolve_page(page, event)
+            .or_else(|| self.resolve_global(event))
+    }
+}
+
+// =============================================================================
+// 工具函数
+// =============================================================================
+
+/// 生成 Colemak 布局预设配置。
+///
+/// 可作为 `config.toml` 中 `[keybindings]` 节的参考示例。
+pub fn colemak_preset() -> KeybindingConfig {
+    let mut global = HashMap::new();
+    global.insert(Action::GlobalNextTrack, "k".to_string());
+    global.insert(Action::GlobalPrevTrack, "h".to_string());
+
+    let mut pages = HashMap::new();
+    let mut search = HashMap::new();
+    search.insert(Action::ListSelectUp, "e".to_string());
+    search.insert(Action::ListSelectDown, "n".to_string());
+    pages.insert("search".to_string(), search);
+
+    KeybindingConfig { global, pages }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_simple_char() {
+        let b = parse_keybinding("q").unwrap();
+        assert_eq!(b.code, KeyCode::Char('q'));
+        assert_eq!(b.modifiers, KeyModifiers::NONE);
+    }
+
+    #[test]
+    fn parse_ctrl_combo() {
+        let b = parse_keybinding("Ctrl+l").unwrap();
+        assert_eq!(b.code, KeyCode::Char('l'));
+        assert_eq!(b.modifiers, KeyModifiers::CONTROL);
+    }
+
+    #[test]
+    fn parse_shift_tab() {
+        let b = parse_keybinding("Shift+Tab").unwrap();
+        assert_eq!(b.code, KeyCode::BackTab);
+        assert_eq!(b.modifiers, KeyModifiers::SHIFT);
+    }
+
+    #[test]
+    fn parse_space() {
+        let b = parse_keybinding("Space").unwrap();
+        assert_eq!(b.code, KeyCode::Char(' '));
+        assert_eq!(b.modifiers, KeyModifiers::NONE);
+    }
+
+    #[test]
+    fn parse_f_key() {
+        let b = parse_keybinding("F5").unwrap();
+        assert_eq!(b.code, KeyCode::F(5));
+    }
+
+    #[test]
+    fn resolver_lookup() {
+        let mut config = KeybindingConfig::default();
+        config.global.insert(Action::GlobalQuit, "q".to_string());
+
+        let resolver = KeybindingResolver::from_config(&config);
+        let event = KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE);
+        assert_eq!(resolver.resolve_global(&event), Some(Action::GlobalQuit));
+    }
+
+    #[test]
+    fn resolver_page_priority() {
+        let mut config = KeybindingConfig::default();
+        config.global.insert(Action::ListSelectDown, "j".to_string());
+
+        let mut search = HashMap::new();
+        search.insert(Action::ListSelectDown, "n".to_string());
+        config.pages.insert("search".to_string(), search);
+
+        let resolver = KeybindingResolver::from_config(&config);
+        let event = KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE);
+        assert_eq!(
+            resolver.resolve("search", &event),
+            Some(Action::ListSelectDown)
+        );
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod events;
+pub mod keybinding;
 pub mod model;
 pub mod traits;
-pub mod events;

--- a/core/src/model/config.rs
+++ b/core/src/model/config.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::source::{Quality, SourceId};
+use crate::keybinding::KeybindingConfig;
 
 pub const CURRENT_CONFIG_VERSION: u32 = 2;
 
@@ -211,6 +212,8 @@ pub struct Config {
     pub ui: UiConfig,
     #[serde(default)]
     pub local_music: LocalMusicConfig,
+    #[serde(default)]
+    pub keybindings: KeybindingConfig,
 }
 
 impl Default for Config {
@@ -224,6 +227,7 @@ impl Default for Config {
             theme: ThemeConfig::default(),
             ui: UiConfig::default(),
             local_music: LocalMusicConfig::default(),
+            keybindings: KeybindingConfig::default(),
         }
     }
 }


### PR DESCRIPTION
我自己的话:
我是一个高度喜欢折腾的人,用的是colemak键位布局(jk对应位置是ne),而非qwerty.所以最初就是为了实现voicefox的键位自定义功能fork了这个项目.在用ai分析阅读项目原代码后,我发现项目的键位都是固定的硬解码,键位不可更改.
最初,在修改代码后,我用新的键位编译,真的很喜欢这个项目,所以我尝试实现了键位的自定义功能,希望能够贡献自己的一份代码.我简单测试了键位配置功能,尽了我最大的努力,可是我个人的使用终究有限,所以也许有其他的bug没有测出来也未可知(愿飞天意面大神保佑).
尽管这样,可是我最大的担忧仍然是这个PR是否符合作者的想法,他的实现方法是否让你满意?或者作者认为有更好的实现方法?或者,其实最初的硬解码其实是作者的偏好?
愿一路顺风.

PR:
实现完整的可配置键位系统，支持全局和页面级两层作用域。
用户可通过 config.toml 自定义所有快捷键，无需修改代码。

Phase 1: 全局键位
- 新增 core/src/keybinding/ 模块（解析器 + 配置结构 + 运行时查表）
- 12 个全局动作可自定义：退出、播放暂停、下一首、上一首、循环模式、 快进/后退、音量加减、标签页切换、返回主界面、收藏切换
- 保留方向键等硬编码别名作为向后兼容 fallback

Phase 2: 页面级键位
- 搜索、队列、排行榜、歌单、收藏、历史、本地音乐、设置、B站登录 共 9 个页面全部迁移到查表模式
- 彻底删除所有页面级硬编码 j/k fallback，键位行为完全由配置控制
- 新增默认页面级键位配置（与原有硬编码行为一致），零行为改变

默认配置完全兼容现有键位，用户无需任何改动即可继续正常使用。
支持单字符、组合键（Ctrl/Shift/Alt）、方向键、功能键等多种键位格式。

Add fully customizable keybinding system with global and page-level scopes. Users can configure all shortcuts via config.toml without code changes.

Phase 1: Global keybindings
- New core/src/keybinding/ module (parser + config + runtime resolver)
- 12 customizable global actions
- Preserves hardcoded aliases for backward compatibility

Phase 2: Page-level keybindings
- All 9 pages migrated to lookup-table resolution
- Removes all hardcoded j/k fallbacks
- Adds default page bindings matching original behavior

Default config is fully backward compatible. Supports single chars, combos (Ctrl/Shift/Alt), arrows, and function keys.