### PR TITLE
fix: 封面和主界面相关的修复和优化

### DIFF
--- a/app/src/cover.rs
+++ b/app/src/cover.rs
@@ -5,9 +5,7 @@ use std::sync::RwLock;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 
-use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
-use ratatui::widgets::Widget;
 use reqwest::header::{ACCEPT, REFERER};
 
 const VOICEFOX_KITTY_IMAGE_ID: u32 = 0x56_46_58;
@@ -30,10 +28,12 @@ pub struct CoverService {
     display_gen: AtomicU64,
     /// 已显示到终端的版本号
     displayed_gen: AtomicU64,
-    /// 上次显示封面时使用的终端区域
+    /// 上次显示封面时使用的终端区域，区域变化（如窗口缩放）时需要重新传输
     displayed_area: RwLock<Option<Rect>>,
     /// Kitty 图层中当前是否有 voicefox 封面
     image_visible: AtomicBool,
+    /// 最近一帧封面的目标区域（封面框的 inner），由 set_display_area 记录
+    display_area: RwLock<Rect>,
 }
 
 impl CoverService {
@@ -56,6 +56,7 @@ impl CoverService {
             displayed_gen: AtomicU64::new(0),
             displayed_area: RwLock::new(None),
             image_visible: AtomicBool::new(false),
+            display_area: RwLock::new(Rect::ZERO),
         }
     }
 
@@ -194,31 +195,29 @@ impl CoverService {
         Ok(cache_path.to_string_lossy().to_string())
     }
 
-    /// 在指定的终端区域显示封面（使用 Kitty 协议）
-    pub fn render(&self, area: Rect, buf: &mut Buffer) {
-        if area.width == 0 || area.height == 0 {
-            return;
-        }
-        // 在 TUI 中留出空白区域（Kitty 图片会浮动在上方）
-        let block = ratatui::widgets::Block::default()
-            .borders(ratatui::widgets::Borders::ALL)
-            .border_style(ratatui::style::Style::new().fg(ratatui::style::Color::DarkGray))
-            .title("封面");
-        block.render(area, buf);
+    /// 当前终端是否支持用 Kitty 图形协议显示封面
+    pub fn kitty_available(&self) -> bool {
+        // tmux 里 TERM 是 screen/tmux，环境探测必然失败，改由 kitten icat 透传承担
+        is_tmux_session()
+            || supports_kitty_graphics() && viuer::get_kitty_support() != viuer::KittySupport::None
+    }
+
+    /// 记录本帧封面图片应占据的区域（TUI 中该区域留空，Kitty 图片浮动在上方）。
+    /// 必须传入封面框的 inner，否则图片会盖住边框。
+    pub fn set_display_area(&self, area: Rect) {
+        *self.display_area.write().unwrap() = area;
     }
 
     /// 在终端中使用 Kitty 协议显示封面（必须在 terminal.draw() 之后调用）
-    pub fn display_kitty(&self, area: Rect) {
+    pub fn display_kitty(&self) {
+        let area = *self.display_area.read().unwrap();
+        if area.width == 0 || area.height == 0 {
+            // 本帧没有封面位置（窗口过窄、或没画封面框），移除已经显示的图片
+            self.clear_display();
+            return;
+        }
         let current_gen = self.display_gen.load(Ordering::SeqCst);
-        let area = cover_image_area(area);
-        let in_tmux = is_tmux_session();
-        if current_gen == 0
-            || area.width == 0
-            || area.height == 0
-            || !in_tmux
-                && (!supports_kitty_graphics()
-                    || viuer::get_kitty_support() == viuer::KittySupport::None)
-        {
+        if current_gen == 0 || !self.kitty_available() {
             return;
         }
         // 同一张图且终端区域未变化时不重复传输。
@@ -240,7 +239,7 @@ impl CoverService {
         // 先清除旧图片，避免新旧图层重叠
         self.clear_display();
 
-        let displayed = if in_tmux {
+        let displayed = if is_tmux_session() {
             display_with_kitten(&path, area)
         } else {
             // 普通终端继续使用 viuer 的 Kitty 协议支持。
@@ -272,18 +271,6 @@ impl CoverService {
             self.delete_kitty_image();
         }
     }
-}
-
-fn cover_image_area(area: Rect) -> Rect {
-    if area.width <= 2 || area.height <= 2 {
-        return Rect::default();
-    }
-    Rect::new(
-        area.x.saturating_add(1),
-        area.y.saturating_add(1),
-        area.width.saturating_sub(2),
-        area.height.saturating_sub(2),
-    )
 }
 
 fn display_with_kitten(path: &str, area: Rect) -> bool {
@@ -436,16 +423,7 @@ mod tests {
 
     use ratatui::layout::Rect;
 
-    use super::{cover_image_area, kitten_icat_args, write_kitty_apc};
-
-    #[test]
-    fn cover_image_stays_inside_the_border() {
-        assert_eq!(
-            cover_image_area(Rect::new(4, 7, 30, 12)),
-            Rect::new(5, 8, 28, 10)
-        );
-        assert_eq!(cover_image_area(Rect::new(0, 0, 2, 2)), Rect::default());
-    }
+    use super::{kitten_icat_args, write_kitty_apc};
 
     #[test]
     fn tmux_kitty_apc_escapes_inner_escape_bytes() {

--- a/app/src/cover.rs
+++ b/app/src/cover.rs
@@ -273,6 +273,51 @@ impl CoverService {
     }
 }
 
+/// 终端单元格的高宽比。失败返回 2.0
+pub fn cell_aspect() -> f32 {
+    let Some((columns, rows, width, height)) = terminal_window_size() else {
+        return 2.0;
+    };
+    if columns == 0 || rows == 0 || width == 0 || height == 0 {
+        return 2.0;
+    }
+    let cell_width = f32::from(width) / f32::from(columns);
+    let cell_height = f32::from(height) / f32::from(rows);
+    if cell_width <= 0.0 {
+        return 2.0;
+    }
+    (cell_height / cell_width).clamp(1.0, 4.0)
+}
+
+/// 封面框应有的高度，返回 0 表示放不下。
+pub fn cover_box_height(box_width: u16, max_height: u16, cell_aspect: f32) -> u16 {
+    let inner_width = box_width.saturating_sub(2);
+    if inner_width == 0 || max_height < 3 {
+        return 0;
+    }
+    let inner_height = (f32::from(inner_width) / cell_aspect).round().max(1.0) as u16;
+    inner_height.saturating_add(2).min(max_height)
+}
+
+/// 封面图片在框内 inner 区域中的实际位置。
+/// - 高度不够时压缩高度、水平居中、两侧留边
+/// - 返回的矩形永远落在 inner 之内
+/// - 封面尺寸假设 1:1，以避免额外的解码路径开销
+pub fn cover_image_rect(inner: Rect, cell_aspect: f32) -> Rect {
+    if inner.width == 0 || inner.height == 0 {
+        return Rect::ZERO;
+    }
+    let fit_height = (f32::from(inner.width) / cell_aspect).round().max(1.0) as u16;
+    if fit_height <= inner.height {
+        let y = inner.y + (inner.height - fit_height) / 2;
+        return Rect::new(inner.x, y, inner.width, fit_height);
+    }
+    let fit_width = ((f32::from(inner.height) * cell_aspect).round().max(1.0) as u16)
+        .clamp(1, inner.width);
+    let x = inner.x + (inner.width - fit_width) / 2;
+    Rect::new(x, inner.y, fit_width, inner.height)
+}
+
 fn display_with_kitten(path: &str, area: Rect) -> bool {
     let args = kitten_icat_args(path, area, terminal_window_size());
     for (program, prefix) in [("kitten", &[][..]), ("kitty", &["+kitten"][..])] {
@@ -423,7 +468,35 @@ mod tests {
 
     use ratatui::layout::Rect;
 
-    use super::{kitten_icat_args, write_kitty_apc};
+    use super::{cover_box_height, cover_image_rect, kitten_icat_args, write_kitty_apc};
+
+    #[test]
+    fn cover_box_height_follows_the_cell_aspect() {
+        // inner 宽 41 → 41/2 ≈ 21 行内容，加上下边框 = 23
+        assert_eq!(cover_box_height(43, 24, 2.0), 23);
+        // 高度不够时被 max_height 压住
+        assert_eq!(cover_box_height(43, 8, 2.0), 8);
+        // 连一行内容都放不下就整个不画
+        assert_eq!(cover_box_height(43, 2, 2.0), 0);
+        assert_eq!(cover_box_height(2, 24, 2.0), 0);
+    }
+
+    #[test]
+    fn cover_image_is_centered_and_never_leaves_the_box() {
+        // 高度充足：正好占满 inner
+        let inner = Rect::new(5, 8, 40, 20);
+        assert_eq!(cover_image_rect(inner, 2.0), inner);
+
+        // 高度被压缩：按高度反推宽度，水平居中留边
+        let squashed = Rect::new(5, 8, 40, 6);
+        let rect = cover_image_rect(squashed, 2.0);
+        assert_eq!(rect, Rect::new(19, 8, 12, 6));
+        assert_eq!(squashed.union(rect), squashed);
+
+        // 极端窄框也不会溢出
+        let tiny = Rect::new(0, 0, 3, 9);
+        assert_eq!(tiny.union(cover_image_rect(tiny, 2.0)), tiny);
+    }
 
     #[test]
     fn tmux_kitty_apc_escapes_inner_escape_bytes() {

--- a/app/src/cover.rs
+++ b/app/src/cover.rs
@@ -312,8 +312,8 @@ pub fn cover_image_rect(inner: Rect, cell_aspect: f32) -> Rect {
         let y = inner.y + (inner.height - fit_height) / 2;
         return Rect::new(inner.x, y, inner.width, fit_height);
     }
-    let fit_width = ((f32::from(inner.height) * cell_aspect).round().max(1.0) as u16)
-        .clamp(1, inner.width);
+    let fit_width =
+        ((f32::from(inner.height) * cell_aspect).round().max(1.0) as u16).clamp(1, inner.width);
     let x = inner.x + (inner.width - fit_width) / 2;
     Rect::new(x, inner.y, fit_width, inner.height)
 }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2080,13 +2080,18 @@ fn start_song_playback(
     let lyric_generation = ctx.lyric_service.prepare();
     let show_cover = ctx.config.read().unwrap().ui.show_cover;
     let cover_service = Arc::clone(&ctx.cover_service);
+    // 队列里的 SongInfo 通常已经带了封面地址，先用它加载一次，不必等播放地址解析完。
+    let initial_cover = song.cover_url.clone();
     if show_cover {
-        let initial_cover = song.cover_url.clone();
+        let initial_cover = initial_cover.clone();
         let cover = Arc::clone(&cover_service);
+        let wake_tx = action_tx.clone();
         rt.spawn(async move {
             if let Err(error) = cover.load(initial_cover).await {
                 tracing::debug!("load initial cover failed: {}", error);
             }
+            // 封面加载不会产生任何事件，暂停时必须主动唤醒渲染循环
+            let _ = wake_tx.send(AppAction::None);
         });
     } else {
         cover_service.clear();
@@ -2203,11 +2208,15 @@ fn start_song_playback(
             resolved_song.source.as_str()
         ))));
 
-        if show_cover {
+        // - 解析结果无封面时不加载
+        // - 解析后的封面地址跟队列里的相同时不再重复加载
+        if show_cover
+            && resolved_song.cover_url.is_some()
+            && resolved_song.cover_url != initial_cover
+        {
             if let Err(error) = cover_service.load(resolved_song.cover_url.clone()).await {
                 tracing::debug!("load cover failed: {}", error);
             }
-            // 封面加载不会产生任何事件，暂停时必须主动唤醒渲染循环
             let _ = tx.send(AppAction::None);
         }
     });

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -277,6 +277,8 @@ fn run_app(
 
     // 事件驱动渲染：借鉴 rmpc，只在有事件或需要渲染时才 draw()
     let mut needs_render = true;
+    // 播放器状态由播放线程改写，没有事件通知，只能靠比对上一轮的值发现变化
+    let mut last_player_state = *ctx.player_state.borrow();
     let max_fps = ctx.config.read().unwrap().ui.max_fps.clamp(1, 60);
     let render_interval = Duration::from_millis(1_000 / u64::from(max_fps));
     let mut last_periodic_render = Instant::now();
@@ -717,9 +719,15 @@ fn run_app(
             last_notification_cleanup = Instant::now();
         }
 
+        // borrow 很便宜，所以不受 render_interval 门控
+        let state = *ctx.player_state.borrow();
+        if state != last_player_state {
+            last_player_state = state;
+            needs_render = true;
+        }
+
         if last_periodic_render.elapsed() >= render_interval {
             ctx.lyric_service.update_position(*ctx.position.borrow());
-            let state = *ctx.player_state.borrow();
             let input_active = active_tab == NavTab::Search
                 && search_page.lock().unwrap().input_mode
                 || active_tab == NavTab::Settings && settings_page.lock().unwrap().input_mode
@@ -1530,6 +1538,8 @@ fn run_app(
                 );
             }
             needs_render = true;
+        } else if matches!(terminal_event, Some(Event::Resize(_, _))) {
+            needs_render = true;
         }
 
         if active_tab == NavTab::Leaderboard {
@@ -2193,9 +2203,12 @@ fn start_song_playback(
             resolved_song.source.as_str()
         ))));
 
-        if show_cover && let Err(error) = cover_service.load(resolved_song.cover_url.clone()).await
-        {
-            tracing::debug!("load cover failed: {}", error);
+        if show_cover {
+            if let Err(error) = cover_service.load(resolved_song.cover_url.clone()).await {
+                tracing::debug!("load cover failed: {}", error);
+            }
+            // 封面加载不会产生任何事件，暂停时必须主动唤醒渲染循环
+            let _ = tx.send(AppAction::None);
         }
     });
 }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -73,7 +73,6 @@ struct UiAreas {
     tabs: Rect,
     content: Rect,
     progress: Rect,
-    cover: Rect,
 }
 
 #[derive(Debug, Default)]
@@ -1601,6 +1600,8 @@ fn draw_app(
     if active_tab != NavTab::Main {
         ctx.cover_service.clear_display();
     }
+    // 封面位置每帧重新记录，先清零，避免窗口过窄不画封面时沿用上一帧的区域
+    ctx.cover_service.set_display_area(Rect::ZERO);
     terminal.draw(|frame| {
         let area = frame.area();
         frame.render_widget(
@@ -1625,20 +1626,10 @@ fn draw_app(
         components::header::render(main_chunks[0], frame.buffer_mut(), ctx);
         pages::sidebar::render(main_chunks[1], frame.buffer_mut(), active_tab, ctx);
         let content_area = main_chunks[2];
-        // 封面区域：匹配 main_page 中 render_cover_placeholder 的位置
-        let cover_area = if active_tab == NavTab::Main && content_area.width >= 72 {
-            let col_w = content_area.width * 36 / 100;
-            let left_w = col_w;
-            let left_h = content_area.height * 62 / 100;
-            Rect::new(content_area.x, content_area.y, left_w, left_h)
-        } else {
-            Rect::default()
-        };
         *ui_areas = UiAreas {
             tabs: main_chunks[1],
             content: content_area,
             progress: main_chunks[3],
-            cover: cover_area,
         };
 
         match active_tab {
@@ -1820,7 +1811,7 @@ fn draw_app(
     })?;
     // 在 Kitty 终端中显示封面（draw 之后，浮动在 TUI 上方）
     if active_tab == NavTab::Main {
-        ctx.cover_service.display_kitty(ui_areas.cover);
+        ctx.cover_service.display_kitty();
     }
     Ok(())
 }

--- a/app/src/pages/components/lyric.rs
+++ b/app/src/pages/components/lyric.rs
@@ -12,6 +12,13 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::context::AppContext;
 
+/// 歌词区最小可用高度（含边框）。
+///
+/// 当前行固定在 inner 的正中（visible_rows / 2），翻译紧跟其后占一行。
+/// 要让「上一句 + 当前行 + 翻译 + 下一句」同时可见，inner 至少要 5 行，
+/// 加上下边框即 7
+pub const MIN_HEIGHT: u16 = 7;
+
 /// 渲染歌词显示
 /// area: 可用区域
 /// 显示当前行前后各 N 行，使当前行尽量居中

--- a/app/src/pages/main_page.rs
+++ b/app/src/pages/main_page.rs
@@ -305,7 +305,7 @@ impl MainPage {
         let block = Block::default()
             .borders(Borders::ALL)
             .border_style(Style::new().fg(crate::theme::border(ctx)))
-            .title(format!(" Queue · {} songs ", songs.len()));
+            .title(format!(" 队列 · {} 歌曲 ", songs.len()));
         let inner = block.inner(area);
         block.render(area, buf);
         if songs.is_empty() {
@@ -393,7 +393,7 @@ fn render_cover_placeholder(area: Rect, buf: &mut Buffer, ctx: &AppContext, cell
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::new().fg(crate::theme::border(ctx)))
-        .title(" Cover ");
+        .title(" 封面 ");
     let inner = block.inner(area);
     block.render(area, buf);
     // 只有终端真的能显示 Kitty 图片时才把 inner 留空，否则退回文字占位
@@ -409,7 +409,7 @@ fn render_cover_placeholder(area: Rect, buf: &mut Buffer, ctx: &AppContext, cell
             vec![
                 Line::from(""),
                 Line::from(Span::styled(
-                    "NO COVER",
+                    "等待播放",
                     Style::new().fg(crate::theme::muted(ctx)),
                 )),
             ]
@@ -432,8 +432,10 @@ fn render_cover_placeholder(area: Rect, buf: &mut Buffer, ctx: &AppContext, cell
                     match &cover_state {
                         crate::cover::CoverState::Loading => "封面加载中...",
                         crate::cover::CoverState::Unavailable(_) => "封面不可用",
-                        crate::cover::CoverState::Empty => "等待播放",
-                        crate::cover::CoverState::Ready => "封面已就绪",
+                        // current_song 非 None 但无封面 <-> 封面被禁用
+                        crate::cover::CoverState::Empty => "",
+                        // 封面就绪但是终端无法显示
+                        crate::cover::CoverState::Ready => "封面无法显示",
                     },
                     Style::new().fg(crate::theme::muted(ctx)),
                 )),

--- a/app/src/pages/main_page.rs
+++ b/app/src/pages/main_page.rs
@@ -385,8 +385,9 @@ fn render_cover_placeholder(area: Rect, buf: &mut Buffer, ctx: &AppContext) {
         .title(" Cover ");
     let inner = block.inner(area);
     block.render(area, buf);
-    if ctx.cover_service.has_image() {
-        ctx.cover_service.render(inner, buf);
+    // 只有终端真的能显示 Kitty 图片时才把 inner 留空，否则退回文字占位
+    if ctx.cover_service.has_image() && ctx.cover_service.kitty_available() {
+        ctx.cover_service.set_display_area(inner);
         return;
     }
     let cover_state = ctx.cover_service.state();

--- a/app/src/pages/main_page.rs
+++ b/app/src/pages/main_page.rs
@@ -222,11 +222,22 @@ impl MainPage {
                 .direction(Direction::Horizontal)
                 .constraints([Constraint::Percentage(36), Constraint::Percentage(64)])
                 .split(area);
+            // 封面框高度由封面比例决定，歌词占满剩余高度，但至少保住 MIN_LYRIC_HEIGHT。
+            let cell_aspect = crate::cover::cell_aspect();
+            let cover_height = crate::cover::cover_box_height(
+                columns[0].width,
+                columns[0]
+                    .height
+                    .saturating_sub(super::components::lyric::MIN_HEIGHT),
+                cell_aspect,
+            );
             let left = Layout::default()
                 .direction(Direction::Vertical)
-                .constraints([Constraint::Percentage(62), Constraint::Percentage(38)])
+                .constraints([Constraint::Length(cover_height), Constraint::Min(0)])
                 .split(columns[0]);
-            render_cover_placeholder(left[0], buf, ctx);
+            if cover_height > 0 {
+                render_cover_placeholder(left[0], buf, ctx, cell_aspect);
+            }
             super::components::lyric::render(left[1], buf, ctx);
             self.render_queue(columns[1], buf, ctx);
         } else {
@@ -378,7 +389,7 @@ fn queue_area(area: Rect) -> Rect {
     }
 }
 
-fn render_cover_placeholder(area: Rect, buf: &mut Buffer, ctx: &AppContext) {
+fn render_cover_placeholder(area: Rect, buf: &mut Buffer, ctx: &AppContext, cell_aspect: f32) {
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::new().fg(crate::theme::border(ctx)))
@@ -387,7 +398,8 @@ fn render_cover_placeholder(area: Rect, buf: &mut Buffer, ctx: &AppContext) {
     block.render(area, buf);
     // 只有终端真的能显示 Kitty 图片时才把 inner 留空，否则退回文字占位
     if ctx.cover_service.has_image() && ctx.cover_service.kitty_available() {
-        ctx.cover_service.set_display_area(inner);
+        ctx.cover_service
+            .set_display_area(crate::cover::cover_image_rect(inner, cell_aspect));
         return;
     }
     let cover_state = ctx.cover_service.state();

--- a/source/src/kw/mod.rs
+++ b/source/src/kw/mod.rs
@@ -60,10 +60,9 @@ impl MusicSource for KwSource {
     }
 
     async fn get_cover_url(&self, song: &SongInfo) -> Result<String, FetchError> {
-        Ok(format!(
-            "http://artistpicserver.kuwo.cn/pic.web?corp=kuwo&type=rid_pic&pictype=500&size=500&rid={}",
-            song.id
-        ))
+        url::resolve_cover_url(&super::http::client(), &song.id)
+            .await
+            .ok_or(FetchError::NotFound)
     }
 
     fn supported_qualities(&self) -> Vec<Quality> {

--- a/source/src/kw/url.rs
+++ b/source/src/kw/url.rs
@@ -22,12 +22,19 @@ fn quality_to_bitrate(quality: Quality) -> u32 {
     }
 }
 
-/// 封面 fallback URL
-fn fallback_cover_url(song_id: &str) -> String {
-    format!(
-        "http://artistpicserver.kuwo.cn/pic.web?corp=kuwo&type=rid_pic&pictype=500&size=500&rid={}",
-        song_id
-    )
+/// 解析封面图片直链。
+///
+/// 优先走 musicInfo API；失败时退回 artistpicserver。后者不是图片地址，
+/// 而是个跳转服务，响应体是一行纯文本形式的真实图片地址。
+pub(super) async fn resolve_cover_url(client: &reqwest::Client, song_id: &str) -> Option<String> {
+    match fetch_cover_url(client, song_id).await {
+        Some(url) => Some(url),
+        None => fetch_artist_pic_url(client, song_id).await,
+    }
+}
+
+fn is_http_url(url: &str) -> bool {
+    url.starts_with("http://") || url.starts_with("https://")
 }
 
 /// 通过 musicInfo API 获取封面图片 URL
@@ -50,17 +57,35 @@ async fn fetch_cover_url(client: &reqwest::Client, song_id: &str) -> Option<Stri
         return None;
     }
 
-    json["data"]["pic"].as_str().map(|s| s.to_string())
+    json["data"]["pic"]
+        .as_str()
+        .map(str::trim)
+        .filter(|pic| is_http_url(pic))
+        .map(str::to_string)
+}
+
+/// 向 artistpicserver 要真实图片地址
+async fn fetch_artist_pic_url(client: &reqwest::Client, song_id: &str) -> Option<String> {
+    let url = format!(
+        "http://artistpicserver.kuwo.cn/pic.web?corp=kuwo&type=rid_pic&pictype=500&size=500&rid={}",
+        song_id
+    );
+
+    let resp = client.get(&url).send().await.ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+
+    let pic = resp.text().await.ok()?.trim().to_string();
+    is_http_url(&pic).then_some(pic)
 }
 
 pub async fn get_song_url(song: &SongInfo, quality: Quality) -> Result<SongUrl, FetchError> {
     let client = http::client();
     let song_id = &song.id;
 
-    // Step 1: 获取封面（优先用 musicInfo，失败用 fallback）
-    let cover_url = fetch_cover_url(&client, song_id)
-        .await
-        .unwrap_or_else(|| fallback_cover_url(song_id));
+    // Step 1: 获取封面；拿不到则留空
+    let cover_url = resolve_cover_url(&client, song_id).await;
 
     // Step 2: 构造播放 URL 请求
     let bitrate = quality_to_bitrate(quality);
@@ -107,7 +132,7 @@ pub async fn get_song_url(song: &SongInfo, quality: Quality) -> Result<SongUrl, 
         url: url_text,
         quality,
         duration: song.duration,
-        cover_url: Some(cover_url),
+        cover_url,
         qualities,
         headers: vec![],
     })


### PR DESCRIPTION
## 修复

- 封面渲染盖住边框
- 暂停状态下封面若加载时间过长有概率不显示
- 非播放或加载状态下终端大小变化有概率不触发重绘
- 切换歌曲后无条件获取封面 url 导致部分情况下发生闪烁或成功获取的封面被丢弃
- 酷我音乐 artistpicserver.kuwo.cn/pic.web 端点获取的真实图片地址被直接当作图片数据返回
- 主界面文本不准确，包括
  - 封面已就绪 -> 封面无法显示
  - 等待播放 -> 空 (封面被禁用)
  - NO COVER -> 等待播放

## 功能变化

- 保持封面宽高比
  - 封面尽可能保持 1:1 宽高比显示, 避免拉伸
  - 歌词占满封面下方剩余高度
  - 歌词至少保留 5 行内容 (空行或歌词 + 上一行 + 当前行 + 当前行翻译 + 下一行) 和 2 行边框

- 统一主界面文本语言为中文
  - Cover -> 封面
  - Queue -> 队列
  - songs -> 歌曲