### PR TITLE
fix: 重置通知显示区域以避免状态栏宽字符残留

### DIFF
--- a/app/src/pages/components/notification.rs
+++ b/app/src/pages/components/notification.rs
@@ -5,7 +5,7 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Paragraph, Widget};
+use ratatui::widgets::{Block, Clear, Paragraph, Widget};
 
 use crate::context::AppContext;
 
@@ -38,7 +38,8 @@ pub fn render(area: Rect, buf: &mut Buffer, ctx: &AppContext) {
             style,
         ));
 
-        if area.height > 0 {
+        if area.height > 0 && area.width > 0 {
+            Clear.render(area, buf);
             Block::default().style(style).render(area, buf);
             Paragraph::new(line).render(Rect::new(area.x, area.y, area.width, 1), buf);
         }


### PR DESCRIPTION
修复显示通知时状态栏部分字符残留的问题. 这一定程度上属于上游 ratatui 处理宽字符时的缺陷, 但能通过简单修复(显示通知前重置缓冲区区域)避免.

## 效果

修复前:

<img width="298" height="65" alt="修复前" src="https://github.com/user-attachments/assets/770f0ab1-d070-4bba-8324-f1fd266e35af" />

修复后:

<img width="298" height="65" alt="修复后" src="https://github.com/user-attachments/assets/e01bd7ea-d057-491f-b528-8d6b2e1358cc" />