### PR TITLE
Fix slash key v2

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1049,10 +1049,7 @@ fn run_app(
                 continue;
             }
 
-            let favorites_filter_key =
-                active_tab == NavTab::Favorites && matches!(key.code, KeyCode::Char('/'));
             if !text_input_active
-                && !favorites_filter_key
                 && let Some(tab) = pages::sidebar::handle_input(&key)
             {
                 active_tab = tab;

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -407,6 +407,7 @@ fn run_app(
     let mut favorites_page = pages::favorites::FavoritesPage::new();
     let mut history_state = SortState::new(SortMode::Newest);
     let mut local_state = SortState::new(SortMode::TitleAsc);
+    let mut local_filter = components::list_filter::ListFilter::new();
     let mut confirm_delete: Option<LocalDeleteConfirmation> = None;
     let mut song_menu: Option<SongContextMenu> = None;
     let mut ui_areas = UiAreas::default();
@@ -921,6 +922,7 @@ fn run_app(
                 &mut favorites_page,
                 &mut history_state,
                 &mut local_state,
+                &local_filter,
                 &mut ui_areas,
                 &confirm_delete,
                 &song_menu,
@@ -946,8 +948,10 @@ fn run_app(
                 active_tab == NavTab::Search && search_page.lock().unwrap().input_mode;
             let favorites_input_mode =
                 active_tab == NavTab::Favorites && favorites_page.input_mode();
+            let local_input_mode =
+                active_tab == NavTab::LocalMusic && local_filter.is_active();
             let text_input_active =
-                settings_input_mode || search_input_mode || favorites_input_mode;
+                settings_input_mode || search_input_mode || favorites_input_mode || local_input_mode;
 
             if let Some(ref page) = bili_login_page {
                 let action = page.lock().unwrap().handle_input(key, &kb_resolver);
@@ -1415,7 +1419,30 @@ fn run_app(
                     }
                 }
                 NavTab::LocalMusic => {
-                    let songs = pages::local_music::sorted_local_songs(&ctx, &local_state);
+                    // 1. 过滤输入模式优先消耗按键
+                    if local_filter.handle_input(&key) {
+                        if !local_filter.is_active() {
+                            local_state.reset_position();
+                        }
+                        needs_render = true;
+                        continue;
+                    }
+
+                    // 2. 计算排序+过滤后的歌曲列表
+                    let all_songs = pages::local_music::sorted_local_songs(&ctx, &local_state);
+                    let songs = if local_filter.query().is_empty() {
+                        all_songs
+                    } else {
+                        let query = local_filter.query().trim().to_lowercase();
+                        all_songs
+                            .into_iter()
+                            .filter(|s| {
+                                s.name.to_lowercase().contains(&query)
+                                    || s.singer.to_lowercase().contains(&query)
+                            })
+                            .collect()
+                    };
+
                     if let Some(action) = kb_resolver.resolve_page("local", &key) {
                         match action {
                             Action::ListCycleSort => {
@@ -1438,6 +1465,10 @@ fn run_app(
                                     &search_seq,
                                 );
                                 local_state.reset_position();
+                                local_filter.reset();
+                            }
+                            Action::LocalFilter => {
+                                local_filter.activate();
                             }
                             Action::ListSelectUp => {
                                 local_state.selected = previous_list_index(
@@ -1552,6 +1583,7 @@ fn run_app(
                                     &search_seq,
                                 );
                                 local_state.reset_position();
+                                local_filter.reset();
                             }
                             (KeyModifiers::NONE, KeyCode::Up) => {
                                 local_state.selected = previous_list_index(
@@ -1877,6 +1909,7 @@ fn run_app(
                 &mut favorites_page,
                 &mut history_state,
                 &mut local_state,
+                &local_filter,
                 &mut ui_areas,
                 &confirm_delete,
                 &song_menu,
@@ -1900,6 +1933,7 @@ fn draw_app(
     favorites_page: &mut pages::favorites::FavoritesPage,
     history_state: &mut SortState,
     local_state: &mut SortState,
+    local_filter: &components::list_filter::ListFilter,
     ui_areas: &mut UiAreas,
     confirm_delete: &Option<LocalDeleteConfirmation>,
     song_menu: &Option<SongContextMenu>,
@@ -1974,28 +2008,58 @@ fn draw_app(
                 'local_content: {
                     let local_src = ctx.source_manager.local_source();
                     let paths = ctx.config.read().unwrap().local_music.paths.clone();
-                    let songs = pages::local_music::sorted_local_songs(ctx, local_state);
+                    let all_songs = pages::local_music::sorted_local_songs(ctx, local_state);
                     let is_scanning = local_src.is_scanning();
+
+                    let songs: Vec<_> = if local_filter.query().is_empty() {
+                        all_songs
+                    } else {
+                        let query = local_filter.query().trim().to_lowercase();
+                        all_songs
+                            .into_iter()
+                            .filter(|s| {
+                                s.name.to_lowercase().contains(&query)
+                                    || s.singer.to_lowercase().contains(&query)
+                            })
+                            .collect()
+                    };
+
                     local_state.selected = local_state.selected.min(songs.len().saturating_sub(1));
+
+                    let filter_suffix = if local_filter.query().is_empty() {
+                        String::new()
+                    } else {
+                        format!(" · 过滤 '{}' ({} 匹配)", local_filter.query(), songs.len())
+                    };
 
                     let block = Block::default()
                         .borders(Borders::ALL)
                         .border_style(Style::new().fg(crate::theme::muted(ctx)))
                         .title(if is_scanning {
                             format!(
-                                "本地音乐 ({} 首，扫描中) · 排序 {} · s 切换",
+                                "本地音乐 ({} 首，扫描中) · 排序 {} · s 切换{}",
                                 songs.len(),
-                                local_state.mode.label(SortTarget::Local)
+                                local_state.mode.label(SortTarget::Local),
+                                filter_suffix
                             )
                         } else {
                             format!(
-                                "本地音乐 ({} 首) · 排序 {} · s 切换",
+                                "本地音乐 ({} 首) · 排序 {} · s 切换{}",
                                 songs.len(),
-                                local_state.mode.label(SortTarget::Local)
+                                local_state.mode.label(SortTarget::Local),
+                                filter_suffix
                             )
                         });
                     let inner = block.inner(content_area);
                     block.render(content_area, frame.buffer_mut());
+
+                    if local_filter.is_active() || !local_filter.query().is_empty() {
+                        local_filter.render(
+                            Rect::new(inner.x, inner.y, inner.width, 1),
+                            frame.buffer_mut(),
+                            ctx,
+                        );
+                    }
 
                     if inner.height < 2 {
                         break 'local_content;
@@ -2022,23 +2086,15 @@ fn draw_app(
                         break 'local_content;
                     }
 
-                    let header = pages::components::song_table::header(inner.width);
-                    Paragraph::new(Line::from(Span::styled(
-                        header,
-                        Style::new()
-                            .fg(crate::theme::text(ctx))
-                            .add_modifier(ratatui::style::Modifier::BOLD),
-                    )))
-                    .render(
-                        Rect::new(inner.x, inner.y, inner.width, 1),
-                        frame.buffer_mut(),
-                    );
+                    let filter_visible = local_filter.is_active() || !local_filter.query().is_empty();
+                    let content_y = if filter_visible { inner.y + 1 } else { inner.y };
+                    let content_height = if filter_visible { inner.height.saturating_sub(1) } else { inner.height };
 
-                    if inner.height < 3 {
+                    if content_height < 3 {
                         break 'local_content;
                     }
 
-                    let visible_height = (inner.height.saturating_sub(2)) as usize;
+                    let visible_height = (content_height.saturating_sub(2)) as usize;
                     let sel = local_state.selected;
                     let mut sc = local_state.scroll;
 
@@ -2049,6 +2105,18 @@ fn draw_app(
                     }
                     sc = sc.min(songs.len().saturating_sub(visible_height));
                     local_state.scroll = sc;
+
+                    let header = pages::components::song_table::header(inner.width);
+                    Paragraph::new(Line::from(Span::styled(
+                        header,
+                        Style::new()
+                            .fg(crate::theme::text(ctx))
+                            .add_modifier(ratatui::style::Modifier::BOLD),
+                    )))
+                    .render(
+                        Rect::new(inner.x, content_y, inner.width, 1),
+                        frame.buffer_mut(),
+                    );
 
                     let end = (sc + visible_height).min(songs.len());
                     for (i, song) in songs.iter().enumerate().take(end).skip(sc) {

--- a/app/src/pages/components/list_filter.rs
+++ b/app/src/pages/components/list_filter.rs
@@ -1,0 +1,270 @@
+//! 通用列表过滤组件
+//!
+//! 为任何需要搜索/过滤功能的列表页面提供统一的输入处理、过滤逻辑和渲染。
+//!
+//! # 用法
+//! ```ignore
+//! let mut filter = ListFilter::new();
+//!
+//! // 在页面 handle_input 中
+//! if filter.handle_input(key) {
+//!     return AppAction::None; // 过滤组件消耗了这个按键
+//! }
+//!
+//! // 切换过滤模式
+//! if action == Action::FavoritesFilter {
+//!     filter.activate();
+//! }
+//!
+//! // 获取过滤后的索引
+//! let filtered = filter.filter(&items, |item, query| {
+//!     item.name.to_lowercase().contains(query)
+//! });
+//! ```
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Paragraph, Widget};
+
+use crate::context::AppContext;
+
+/// 列表过滤状态
+#[derive(Debug, Clone)]
+pub struct ListFilter {
+    query: String,
+    active: bool,
+}
+
+impl Default for ListFilter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ListFilter {
+    pub fn new() -> Self {
+        Self {
+            query: String::new(),
+            active: false,
+        }
+    }
+
+    /// 当前是否在输入模式
+    pub fn is_active(&self) -> bool {
+        self.active
+    }
+
+    /// 当前过滤字符串
+    pub fn query(&self) -> &str {
+        &self.query
+    }
+
+    #[cfg(test)]
+    pub fn set_query(&mut self, query: impl Into<String>) {
+        self.query = query.into();
+    }
+
+    /// 进入过滤输入模式
+    pub fn activate(&mut self) {
+        self.active = true;
+    }
+
+    /// 退出过滤输入模式（不清除 query）
+    pub fn deactivate(&mut self) {
+        self.active = false;
+    }
+
+    /// 完全重置（清除 query 并退出输入模式）
+    pub fn reset(&mut self) {
+        self.query.clear();
+        self.active = false;
+    }
+
+    /// 处理按键输入。
+    ///
+    /// 当过滤组件处于激活状态时，消耗所有字符输入、Backspace、Esc 和 Enter。
+    /// 返回 `true` 表示按键已被消耗，页面不应再处理。
+    ///
+    /// # 按键映射
+    /// - `Esc` → 退出输入模式，保留 query 作为过滤条件
+    /// - `Enter` → 退出输入模式，保留 query
+    /// - `Backspace` → 删除最后一个字符，同时重置选中到顶部
+    /// - 普通字符 → 追加到 query，同时重置选中到顶部
+    pub fn handle_input(&mut self, key: &KeyEvent) -> bool {
+        if !self.active {
+            return false;
+        }
+
+        match (key.modifiers, key.code) {
+            (KeyModifiers::NONE, KeyCode::Esc) => {
+                self.active = false;
+                true
+            }
+            (KeyModifiers::NONE, KeyCode::Enter) => {
+                self.active = false;
+                true
+            }
+            (_, KeyCode::Backspace)
+                if !key
+                    .modifiers
+                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+            {
+                self.query.pop();
+                true
+            }
+            (_, KeyCode::Char(character))
+                if !key
+                    .modifiers
+                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+            {
+                self.query.push(character);
+                true
+            }
+            _ => true, // 激活状态下消耗所有其他按键，防止误触发全局快捷键
+        }
+    }
+
+    /// 对列表进行过滤，返回匹配项的原始索引。
+    ///
+    /// # 参数
+    /// - `items` — 原始列表
+    /// - `matcher` — 匹配函数，接收 `(item, query)` 返回是否匹配
+    ///
+    /// # 返回值
+    /// 匹配项在原始列表中的索引数组。query 为空时返回全部索引。
+    pub fn filter<T>(
+        &self,
+        items: &[T],
+        matcher: impl Fn(&T, &str) -> bool,
+    ) -> Vec<usize> {
+        let query = self.query.trim().to_lowercase();
+        if query.is_empty() {
+            return (0..items.len()).collect();
+        }
+        items
+            .iter()
+            .enumerate()
+            .filter_map(|(index, item)| {
+                matcher(item, &query).then_some(index)
+            })
+            .collect()
+    }
+
+    /// 渲染过滤输入栏。
+    ///
+    /// 在区域顶部渲染一个高度为 1 的行，显示当前模式（INSERT/FILTER）和 query。
+    /// 仅在 `active == true` 或 `query` 非空时渲染有实际内容；
+    /// 调用方应根据此方法是否产生可见内容来调整列表区域。
+    pub fn render(&self, area: Rect, buf: &mut Buffer, ctx: &AppContext) {
+        let mode = if self.active { "INSERT" } else { "FILTER" };
+        let accent = crate::theme::accent(ctx);
+        Paragraph::new(Line::from(vec![
+            Span::styled(
+                format!(" / {} ", mode),
+                Style::new()
+                    .fg(crate::theme::selection_fg(ctx))
+                    .bg(accent)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!(" {} ", self.query),
+                Style::new()
+                    .fg(crate::theme::text(ctx))
+                    .bg(crate::theme::surface0(ctx)),
+            ),
+        ]))
+        .style(Style::new().bg(crate::theme::surface0(ctx)))
+        .render(area, buf);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ListFilter;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    #[test]
+    fn new_filter_is_inactive_with_empty_query() {
+        let f = ListFilter::new();
+        assert!(!f.is_active());
+        assert_eq!(f.query(), "");
+    }
+
+    #[test]
+    fn activate_and_deactivate() {
+        let mut f = ListFilter::new();
+        f.activate();
+        assert!(f.is_active());
+        f.deactivate();
+        assert!(!f.is_active());
+        assert_eq!(f.query(), ""); // query 保留
+    }
+
+    #[test]
+    fn reset_clears_everything() {
+        let mut f = ListFilter::new();
+        f.activate();
+        f.query.push_str("hello");
+        f.reset();
+        assert!(!f.is_active());
+        assert_eq!(f.query(), "");
+    }
+
+    #[test]
+    fn inactive_filter_returns_all_indices() {
+        let f = ListFilter::new();
+        let items = vec!["a", "b", "c"];
+        let filtered = f.filter(&items, |item, q| item.contains(q));
+        assert_eq!(filtered, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn filter_matches_case_insensitive() {
+        let mut f = ListFilter::new();
+        f.query = "hello".into();
+        let items = vec!["Hello World", "goodbye", "HELLO"];
+        let filtered = f.filter(&items, |item, q| item.to_lowercase().contains(q));
+        assert_eq!(filtered, vec![0, 2]);
+    }
+
+    #[test]
+    fn handle_input_consumes_when_active() {
+        let mut f = ListFilter::new();
+        f.activate();
+
+        // 字符输入
+        let key = KeyEvent::from(KeyCode::Char('a'));
+        assert!(f.handle_input(&key));
+        assert_eq!(f.query(), "a");
+
+        // Backspace
+        let key = KeyEvent::from(KeyCode::Backspace);
+        assert!(f.handle_input(&key));
+        assert_eq!(f.query(), "");
+
+        // Esc 退出
+        let key = KeyEvent::from(KeyCode::Esc);
+        assert!(f.handle_input(&key));
+        assert!(!f.is_active());
+    }
+
+    #[test]
+    fn handle_input_passes_through_when_inactive() {
+        let mut f = ListFilter::new();
+        let key = KeyEvent::from(KeyCode::Char('a'));
+        assert!(!f.handle_input(&key));
+        assert_eq!(f.query(), "");
+    }
+
+    #[test]
+    fn empty_query_returns_all() {
+        let mut f = ListFilter::new();
+        f.query = "   ".into(); // 只有空格，trim 后为空
+        let items = vec!["x", "y"];
+        let filtered = f.filter(&items, |item, q| item.contains(q));
+        assert_eq!(filtered, vec![0, 1]);
+    }
+}

--- a/app/src/pages/components/mod.rs
+++ b/app/src/pages/components/mod.rs
@@ -7,6 +7,7 @@
 
 pub mod context_menu;
 pub mod header;
+pub mod list_filter;
 pub mod lyric;
 pub mod notification;
 pub mod progress_bar;

--- a/app/src/pages/favorites.rs
+++ b/app/src/pages/favorites.rs
@@ -16,8 +16,7 @@ use crate::pages::sort::{SortMode, SortTarget, sorted_indices};
 pub struct FavoritesPage {
     selected: usize,
     scroll: usize,
-    query: String,
-    search_mode: bool,
+    filter: super::components::list_filter::ListFilter,
     viewport_height: usize,
     sort_mode: SortMode,
 }
@@ -27,15 +26,14 @@ impl FavoritesPage {
         Self {
             selected: 0,
             scroll: 0,
-            query: String::new(),
-            search_mode: false,
+            filter: super::components::list_filter::ListFilter::new(),
             viewport_height: 1,
             sort_mode: SortMode::Newest,
         }
     }
 
     pub fn input_mode(&self) -> bool {
-        self.search_mode
+        self.filter.is_active()
     }
 
     pub fn sort_mode(&self) -> SortMode {
@@ -59,49 +57,24 @@ impl FavoritesPage {
         ctx: &AppContext,
         resolver: &KeybindingResolver,
     ) -> AppAction {
-        if self.search_mode {
-            match (key.modifiers, key.code) {
-                (KeyModifiers::NONE, KeyCode::Esc) => {
-                    self.search_mode = false;
-                    self.query.clear();
-                    self.selected = 0;
-                    self.scroll = 0;
-                }
-                (KeyModifiers::NONE, KeyCode::Enter) => {
-                    self.search_mode = false;
-                }
-                (_, KeyCode::Backspace)
-                    if !key
-                        .modifiers
-                        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
-                {
-                    self.query.pop();
-                    self.selected = 0;
-                    self.scroll = 0;
-                }
-                (_, KeyCode::Char(character))
-                    if !key
-                        .modifiers
-                        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
-                {
-                    self.query.push(character);
-                    self.selected = 0;
-                    self.scroll = 0;
-                }
-                _ => {}
+        let query_before = self.filter.query().to_string();
+        if self.filter.handle_input(key) {
+            if self.filter.query() != query_before {
+                self.selected = 0;
+                self.scroll = 0;
             }
             return AppAction::None;
         }
 
         let favorites = ctx.storage.load_favorites();
-        let filtered = self.filtered_indices(&favorites);
+        let filtered = self.filtered_song_indices(&favorites);
         self.clamp_selection(filtered.len());
         let half_page = (self.viewport_height / 2).max(1);
 
         if let Some(action) = resolver.resolve_page("favorites", key) {
             match action {
                 Action::FavoritesFilter => {
-                    self.search_mode = true;
+                    self.filter.activate();
                     return AppAction::None;
                 }
                 Action::ListCycleSort => {
@@ -192,7 +165,7 @@ impl FavoritesPage {
                         && ctx.storage.remove_favorite(song)
                     {
                         let remaining = ctx.storage.load_favorites();
-                        let remaining_len = self.filtered_indices(&remaining).len();
+                        let remaining_len = self.filtered_song_indices(&remaining).len();
                         self.clamp_selection(remaining_len);
                         return AppAction::ShowNotification(lx_core::events::Notification::info(
                             "已取消收藏",
@@ -201,10 +174,10 @@ impl FavoritesPage {
                     return AppAction::None;
                 }
                 Action::ListGoBack => {
-                    if self.query.is_empty() {
+                    if self.filter.query().is_empty() {
                         return AppAction::GoBack;
                     }
-                    self.query.clear();
+                    self.filter.reset();
                     self.selected = 0;
                     self.scroll = 0;
                     return AppAction::None;
@@ -215,7 +188,7 @@ impl FavoritesPage {
 
         match (key.modifiers, key.code) {
             (KeyModifiers::NONE, KeyCode::Char('/')) => {
-                self.search_mode = true;
+                self.filter.activate();
             }
             (KeyModifiers::NONE, KeyCode::Char('s')) => {
                 let mode = self.cycle_sort();
@@ -225,10 +198,10 @@ impl FavoritesPage {
                 )));
             }
             (KeyModifiers::NONE, KeyCode::Esc) => {
-                if self.query.is_empty() {
+                if self.filter.query().is_empty() {
                     return AppAction::GoBack;
                 }
-                self.query.clear();
+                self.filter.reset();
                 self.selected = 0;
                 self.scroll = 0;
             }
@@ -310,7 +283,7 @@ impl FavoritesPage {
                     && ctx.storage.remove_favorite(song)
                 {
                     let remaining = ctx.storage.load_favorites();
-                    let remaining_len = self.filtered_indices(&remaining).len();
+                    let remaining_len = self.filtered_song_indices(&remaining).len();
                     self.clamp_selection(remaining_len);
                     return AppAction::ShowNotification(lx_core::events::Notification::info(
                         "已取消收藏",
@@ -324,7 +297,7 @@ impl FavoritesPage {
 
     pub fn render(&mut self, area: Rect, buf: &mut Buffer, ctx: &AppContext) {
         let favorites = ctx.storage.load_favorites();
-        let filtered = self.filtered_indices(&favorites);
+        let filtered = self.filtered_song_indices(&favorites);
         self.clamp_selection(filtered.len());
 
         let block = Block::default()
@@ -342,27 +315,14 @@ impl FavoritesPage {
             return;
         }
 
-        let show_search = self.search_mode || !self.query.is_empty();
+        let show_search = self.filter.is_active() || !self.filter.query().is_empty();
         let mut cursor_y = inner.y;
         if show_search {
-            let mode = if self.search_mode { "INSERT" } else { "FILTER" };
-            Paragraph::new(Line::from(vec![
-                Span::styled(
-                    format!(" / {} ", mode),
-                    Style::new()
-                        .fg(crate::theme::selection_fg(ctx))
-                        .bg(crate::theme::mauve(ctx))
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::styled(
-                    format!(" {} ", self.query),
-                    Style::new()
-                        .fg(crate::theme::text(ctx))
-                        .bg(crate::theme::surface0(ctx)),
-                ),
-            ]))
-            .style(Style::new().bg(crate::theme::surface0(ctx)))
-            .render(Rect::new(inner.x, cursor_y, inner.width, 1), buf);
+            self.filter.render(
+                Rect::new(inner.x, cursor_y, inner.width, 1),
+                buf,
+                ctx,
+            );
             cursor_y = cursor_y.saturating_add(1);
         }
 
@@ -393,7 +353,7 @@ impl FavoritesPage {
             return;
         }
         if filtered.is_empty() {
-            Paragraph::new(format!("没有匹配“{}”的歌曲", self.query))
+            Paragraph::new(format!("没有匹配“{}”的歌曲", self.filter.query()))
                 .style(Style::new().fg(crate::theme::overlay1(ctx)))
                 .render(list, buf);
             return;
@@ -441,7 +401,7 @@ impl FavoritesPage {
         activate: bool,
     ) -> AppAction {
         let favorites = ctx.storage.load_favorites();
-        let filtered = self.filtered_indices(&favorites);
+        let filtered = self.filtered_song_indices(&favorites);
         let scroll_amount = ctx.config.read().unwrap().ui.scroll_amount.max(1);
         match event.kind {
             MouseEventKind::ScrollUp => {
@@ -453,9 +413,10 @@ impl FavoritesPage {
             }
             MouseEventKind::Down(MouseButton::Left) => {
                 let inner = Block::default().borders(Borders::ALL).inner(area);
-                let search_height = u16::from(self.search_mode || !self.query.is_empty());
+                let search_height =
+                    u16::from(self.filter.is_active() || !self.filter.query().is_empty());
                 if search_height == 1 && event.row == inner.y {
-                    self.search_mode = true;
+                    self.filter.activate();
                     return AppAction::None;
                 }
                 let list_y = inner.y.saturating_add(search_height).saturating_add(1);
@@ -488,9 +449,10 @@ impl FavoritesPage {
         ctx: &AppContext,
     ) -> Option<(Vec<SongInfo>, usize)> {
         let favorites = ctx.storage.load_favorites();
-        let filtered = self.filtered_indices(&favorites);
+        let filtered = self.filtered_song_indices(&favorites);
         let inner = Block::default().borders(Borders::ALL).inner(area);
-        let search_height = u16::from(self.search_mode || !self.query.is_empty());
+        let search_height =
+            u16::from(self.filter.is_active() || !self.filter.query().is_empty());
         let list_y = inner.y.saturating_add(search_height).saturating_add(1);
         if event.row < list_y || event.row >= inner.bottom() {
             return None;
@@ -503,13 +465,13 @@ impl FavoritesPage {
             .iter()
             .filter_map(|original| favorites.get(*original).cloned())
             .collect::<Vec<_>>();
-        self.search_mode = false;
+        self.filter.deactivate();
         self.selected = index;
         Some((songs, index))
     }
 
-    fn filtered_indices(&self, favorites: &[SongInfo]) -> Vec<usize> {
-        let query = self.query.trim().to_lowercase();
+    fn filtered_song_indices(&self, favorites: &[SongInfo]) -> Vec<usize> {
+        let query = self.filter.query().trim().to_lowercase();
         sorted_indices(favorites, self.sort_mode, SortTarget::Favorites)
             .into_iter()
             .filter(|index| {
@@ -521,6 +483,7 @@ impl FavoritesPage {
                     || song.source.as_str().contains(&query)
             })
             .collect()
+    }
     }
 
     fn clamp_selection(&mut self, len: usize) {
@@ -549,8 +512,8 @@ mod tests {
         let songs = vec![song];
 
         for query in ["晴天", "周杰伦", "叶惠美", "kw"] {
-            page.query = query.into();
-            assert_eq!(page.filtered_indices(&songs), vec![0]);
+            page.filter.set_query(query);
+            assert_eq!(page.filtered_song_indices(&songs), vec![0]);
         }
     }
 

--- a/app/src/pages/favorites.rs
+++ b/app/src/pages/favorites.rs
@@ -484,7 +484,6 @@ impl FavoritesPage {
             })
             .collect()
     }
-    }
 
     fn clamp_selection(&mut self, len: usize) {
         if len == 0 {
@@ -525,8 +524,8 @@ mod tests {
             SongInfo::new("2".into(), SourceId::Kw, "B".into(), "Y".into()),
         ];
 
-        assert_eq!(page.filtered_indices(&songs), vec![1, 0]);
+        assert_eq!(page.filtered_song_indices(&songs), vec![1, 0]);
         assert_eq!(page.cycle_sort(), SortMode::Oldest);
-        assert_eq!(page.filtered_indices(&songs), vec![0, 1]);
+        assert_eq!(page.filtered_song_indices(&songs), vec![0, 1]);
     }
 }

--- a/app/src/pages/sidebar.rs
+++ b/app/src/pages/sidebar.rs
@@ -96,7 +96,6 @@ fn tab_chunks(area: Rect) -> std::rc::Rc<[Rect]> {
 /// 处理侧边栏全局快捷键，返回要切换到的标签页
 pub fn handle_input(key: &KeyEvent) -> Option<NavTab> {
     match (key.modifiers, key.code) {
-        (KeyModifiers::NONE, KeyCode::Char('/')) => Some(NavTab::Search),
         (KeyModifiers::NONE, KeyCode::Char('1')) => Some(NavTab::Main),
         (KeyModifiers::NONE, KeyCode::Char('2')) => Some(NavTab::Search),
         (KeyModifiers::NONE, KeyCode::Char('3')) => Some(NavTab::Leaderboard),

--- a/core/src/keybinding/mod.rs
+++ b/core/src/keybinding/mod.rs
@@ -91,6 +91,8 @@ pub enum Action {
     LocalRescan,
     /// 删除选中的本地文件（弹出确认）
     LocalDelete,
+    /// 进入本地音乐过滤模式
+    LocalFilter,
 
     // --- 收藏页面专用 ---
     /// 进入过滤模式
@@ -292,6 +294,7 @@ fn default_page_bindings() -> HashMap<String, HashMap<Action, String>> {
     local.insert(Action::ListCycleSort, "s".to_string());
     local.insert(Action::LocalRescan, "r".to_string());
     local.insert(Action::LocalDelete, "d".to_string());
+    local.insert(Action::LocalFilter, "/".to_string());
     pages.insert("local".to_string(), local);
 
     // --- 设置 ---


### PR DESCRIPTION
fix: 解决 / 键冲突并为本地音乐添加过滤功能
PR 描述
## 问题

`/` 键目前在不同页面有不同语义，造成冲突：

1. **全局**：`/` 跳转到搜索页（`sidebar.rs` 中硬编码）
2. **搜索页**：`/` 进入输入模式（输入搜索关键词）
3. **收藏页**：`/` 进入过滤模式（筛选收藏歌曲）

这会导致意外行为。例如，在本地音乐页按 `/`，本应希望过滤本地歌曲，却会跳转到搜索页。

此外，本地音乐页目前没有任何过滤功能，歌曲多了以后很难找到想听的。

## 解决方案

本 PR 分三步解决：

### 1. 删除全局 `/` 跳转（`03bff84`）

- 从 `sidebar.rs` 中删除 `/` → 搜索页 的全局绑定
- 从 `main.rs` 中删除 `favorites_filter_key` 的特殊处理 workaround
- 现在每个页面可以独立定义 `/` 的行为

### 2. 提取可复用的 `ListFilter` 组件（`e49213b`）

- 把 `FavoritesPage` 内联的过滤逻辑提取到 `pages/components/list_filter.rs`
- 提供统一接口：`handle_input()`（输入处理）、`filter()`（过滤）、`render()`（渲染）
- 收藏页行为零改变，且已适配 v1.2 排序功能

### 3. 为本地音乐页添加 `/` 过滤（`afbfa54`）

- 在键位配置中新增 `Action::LocalFilter`，默认绑定 `/`
- 在本地音乐页集成 `ListFilter` 组件
- **排序后过滤**：先按当前排序方式排序，再按歌名/歌手过滤（不区分大小写）
- `Esc` / `Enter` 退出过滤模式；`r`（重新扫描）重置过滤
- 标题显示匹配数量；无匹配时给出提示

## 关键设计决策

- **不包含 GlobalGoToMain 删除**：本 PR 故意不包含删除 Esc 全局返回主页的修改。那个改动更有争议，会单独提 PR 讨论。
- **兼容 v1.2 SortState 架构**：本地音乐过滤已适配 v1.2 引入的 `SortState { selected, scroll, mode }` 新架构。
- **一致的交互体验**：`/` 现在在收藏页和本地音乐页都表示"过滤"，语义统一。