### PR TITLE
fix: clamp negative seconds to prevent Duration panic

### DIFF
--- a/player/src/engine.rs
+++ b/player/src/engine.rs
@@ -159,7 +159,7 @@ impl Player for MpvEngine {
                         if let Some(ref pos_str) = pos_res
                             && let Some(secs) = parse_mpv_data(pos_str)
                         {
-                            let _ = position_tx.send(Duration::from_secs_f64(secs));
+                            let _ = position_tx.send(Duration::from_secs_f64(secs.max(0.0)));
                         }
 
                         // 总时长变化频率很低，每秒查询一次即可。
@@ -173,7 +173,7 @@ impl Player for MpvEngine {
                             if let Some(ref dur_str) = dur_res
                                 && let Some(secs) = parse_mpv_data(dur_str)
                             {
-                                let _ = duration_tx.send(Duration::from_secs_f64(secs));
+                                let _ = duration_tx.send(Duration::from_secs_f64(secs.max(0.0)));
                             }
                         }
                         tick = tick.wrapping_add(1);


### PR DESCRIPTION
mpv can report negative position/duration values, which causes `Duration::from_secs_f64` to panic. Use `.max(0.0)` to clamp.

<img width="1388" height="250" alt="图片" src="https://github.com/user-attachments/assets/51eb37fa-b84b-4b0e-be1d-b64987198917" />
