### PR TITLE
fix: 正确显示本地音乐和Bilibili音源的音质

### DIFF
--- a/app/src/pages/components/song_table.rs
+++ b/app/src/pages/components/song_table.rs
@@ -1,5 +1,4 @@
 use lx_core::model::song::SongInfo;
-use lx_core::model::source::Quality;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 pub fn header(width: u16) -> String {
@@ -18,12 +17,7 @@ pub fn header(width: u16) -> String {
 pub fn row(song: &SongInfo, index: usize, width: u16) -> String {
     let index = (index + 1).to_string();
     let duration = format_duration(song.duration);
-    let quality = song
-        .qualities
-        .iter()
-        .next_back()
-        .map(|quality| quality_label(*quality))
-        .unwrap_or("-");
+    let quality = song.quality_label();
 
     format_columns(
         width as usize,
@@ -32,7 +26,7 @@ pub fn row(song: &SongInfo, index: usize, width: u16) -> String {
         &song.singer,
         &song.album_name,
         &duration,
-        quality,
+        &quality,
         song.source.as_str(),
     )
 }
@@ -49,7 +43,7 @@ fn format_columns(
     source: &str,
 ) -> String {
     if width >= 96 {
-        let fixed = 4 + 20 + 7 + 8 + 7;
+        let fixed = 4 + 20 + 7 + 9 + 7;
         let flexible = width.saturating_sub(fixed);
         let name_width = flexible.div_ceil(2);
         let album_width = flexible.saturating_sub(name_width);
@@ -59,7 +53,7 @@ fn format_columns(
             cell(singer, 20),
             cell(album, album_width),
             cell(duration, 7),
-            cell(quality, 8),
+            cell(quality, 9),
             cell(source, 7),
         ]
         .concat();
@@ -127,15 +121,6 @@ fn format_duration(duration: std::time::Duration) -> String {
     }
     let total = duration.as_secs();
     format!("{:02}:{:02}", total / 60, total % 60)
-}
-
-fn quality_label(quality: Quality) -> &'static str {
-    match quality {
-        Quality::Low128 => "128K",
-        Quality::High320 => "320K",
-        Quality::Flac => "FLAC",
-        Quality::Flac24 => "Hi-Res",
-    }
 }
 
 #[cfg(test)]

--- a/app/src/pages/components/status_bar.rs
+++ b/app/src/pages/components/status_bar.rs
@@ -1,7 +1,7 @@
 //! 底部状态栏
 
 use lx_core::model::config::StatusBarItem;
-use lx_core::model::source::{PlayerState, Quality};
+use lx_core::model::source::PlayerState;
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
@@ -143,7 +143,7 @@ pub fn render(area: Rect, buf: &mut Buffer, ctx: &AppContext, sort_status: Optio
                 Style::new().fg(crate::theme::lavender(ctx)).bg(background),
             )),
             StatusBarItem::Quality => Some((
-                quality_label(quality).to_string(),
+                quality.label().to_string(),
                 Style::new().fg(crate::theme::peach(ctx)).bg(background),
             )),
             StatusBarItem::Queue => Some((
@@ -245,15 +245,6 @@ fn truncate(value: &str, width: usize) -> String {
     }
     result.push('…');
     result
-}
-
-fn quality_label(quality: Quality) -> &'static str {
-    match quality {
-        Quality::Low128 => "128K",
-        Quality::High320 => "320K",
-        Quality::Flac => "FLAC",
-        Quality::Flac24 => "Hi-Res",
-    }
 }
 
 fn format_duration(duration: std::time::Duration) -> String {

--- a/app/src/pages/settings.rs
+++ b/app/src/pages/settings.rs
@@ -928,7 +928,7 @@ impl SettingsPage {
             ),
             setting_value_line(
                 "播放音质",
-                quality_label(config.player.quality),
+                config.player.quality.label(),
                 "Q",
                 accent,
                 muted,
@@ -1553,15 +1553,6 @@ fn next_quality(quality: Quality) -> Quality {
         Quality::High320 => Quality::Flac,
         Quality::Flac => Quality::Flac24,
         Quality::Flac24 => Quality::Low128,
-    }
-}
-
-fn quality_label(quality: Quality) -> &'static str {
-    match quality {
-        Quality::Low128 => "128k",
-        Quality::High320 => "320k",
-        Quality::Flac => "FLAC",
-        Quality::Flac24 => "Hi-Res",
     }
 }
 

--- a/core/src/model/song.rs
+++ b/core/src/model/song.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeSet, HashMap};
 use std::path::PathBuf;
 use std::time::Duration;
 
-use super::source::{Quality, SourceId};
+use super::source::{AudioProperties, Quality, SourceId};
 
 pub const EXTRA_FILE_MODIFIED_UNIX_NANOS: &str = "file_modified_unix_nanos";
 
@@ -20,6 +20,9 @@ pub struct SongInfo {
     pub duration: Duration,
     pub cover_url: Option<String>,
     pub qualities: BTreeSet<Quality>,
+    /// 实际编码参数，仅本地文件可获取
+    #[serde(default)]
+    pub audio: Option<AudioProperties>,
 
     /// 音源特有数据（按 key 存取）
     pub extra: HashMap<String, String>,
@@ -44,10 +47,25 @@ impl SongInfo {
             duration: Duration::ZERO,
             cover_url: None,
             qualities: BTreeSet::new(),
+            audio: None,
             extra: HashMap::new(),
             toggle_source: None,
             file_path: None,
             file_ext: None,
         }
+    }
+
+    /// 界面显示的音质文本
+    ///
+    /// - 本地文件 - 实测规格
+    /// - 在线音源 - 回落到档位
+    pub fn quality_label(&self) -> String {
+        if let Some(label) = self.audio.as_ref().and_then(AudioProperties::label) {
+            return label;
+        }
+        self.qualities
+            .iter()
+            .next_back()
+            .map_or_else(|| "-".to_string(), |quality| quality.label().to_string())
     }
 }

--- a/core/src/model/source.rs
+++ b/core/src/model/source.rs
@@ -57,6 +57,18 @@ pub enum Quality {
     Flac24,
 }
 
+impl Quality {
+    /// 档位标签
+    pub fn label(self) -> &'static str {
+        match self {
+            Quality::Low128 => "128K",
+            Quality::High320 => "320K",
+            Quality::Flac => "FLAC",
+            Quality::Flac24 => "Hi-Res",
+        }
+    }
+}
+
 /// 音质尝试顺序（高→低）
 pub const QUALITY_ORDER: &[Quality] = &[
     Quality::Flac24,
@@ -64,6 +76,44 @@ pub const QUALITY_ORDER: &[Quality] = &[
     Quality::High320,
     Quality::Low128,
 ];
+
+/// 音频文件的实际编码参数
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AudioProperties {
+    /// 音频流码率（kb/s）
+    pub bitrate: Option<u32>,
+    /// 采样率（Hz）
+    pub sample_rate: Option<u32>,
+    /// 位深（bit）
+    pub bit_depth: Option<u8>,
+    /// 是否为无损编码
+    pub lossless: bool,
+}
+
+impl AudioProperties {
+    /// 实测规格标签
+    ///
+    /// 无损编码的码率不表示规格，取位深与采样率。有损编码的码率即规格
+    pub fn label(&self) -> Option<String> {
+        if self.lossless {
+            return match (self.bit_depth, self.sample_rate) {
+                (Some(depth), Some(rate)) => Some(format!("{}/{}", depth, format_khz(rate))),
+                (None, Some(rate)) => Some(format!("{}kHz", format_khz(rate))),
+                _ => None,
+            };
+        }
+        self.bitrate.map(|bitrate| format!("{}K", bitrate))
+    }
+}
+
+/// 采样率转 kHz 显示，整千值省去小数部分
+fn format_khz(hz: u32) -> String {
+    if hz.is_multiple_of(1000) {
+        (hz / 1000).to_string()
+    } else {
+        format!("{:.1}", hz as f64 / 1000.0)
+    }
+}
 
 /// 播放器状态
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/source/src/bili/search.rs
+++ b/source/src/bili/search.rs
@@ -2,7 +2,7 @@ use std::sync::OnceLock;
 use std::time::Duration;
 
 use lx_core::model::song::SongInfo;
-use lx_core::model::source::{Quality, SourceId};
+use lx_core::model::source::SourceId;
 use lx_core::traits::source::{SearchError, SearchResult};
 use regex::Regex;
 use reqwest::Url;
@@ -237,7 +237,6 @@ fn parse_video_result(
             song.album_id = bvid.to_string();
             song.duration = Duration::from_secs(page["duration"].as_u64().unwrap_or_default());
             song.cover_url = cover_url.clone();
-            song.qualities.extend([Quality::Low128, Quality::High320]);
             song.extra.insert("bvid".to_string(), bvid.to_string());
             song.extra.insert("cid".to_string(), cid);
             song.extra
@@ -263,7 +262,6 @@ fn parse_video_result(
             song.album_id = bvid.to_string();
             song.duration = Duration::from_secs(data["duration"].as_u64().unwrap_or_default());
             song.cover_url = cover_url;
-            song.qualities.extend([Quality::Low128, Quality::High320]);
             song.extra.insert("bvid".to_string(), bvid.to_string());
             song.extra.insert("cid".to_string(), cid);
             song.extra.insert("page".to_string(), "1".to_string());
@@ -521,6 +519,25 @@ mod tests {
             result.items[0].cover_url.as_deref(),
             Some("https://example.com/cover.jpg")
         );
+    }
+
+    #[test]
+    fn expanded_parts_carry_no_quality_until_a_stream_is_chosen() {
+        let json = json!({
+            "code": 0,
+            "data": {
+                "bvid": "BV1xx411c7mD",
+                "title": "测试视频",
+                "owner": {"name": "UP主", "mid": 42},
+                "pages": [
+                    {"cid": 1001, "page": 1, "part": "第一段", "duration": 60}
+                ]
+            }
+        });
+
+        let result = parse_video_result(&json, None).unwrap();
+
+        assert!(result.items[0].qualities.is_empty());
     }
 
     #[test]

--- a/source/src/local/metadata.rs
+++ b/source/src/local/metadata.rs
@@ -3,10 +3,11 @@
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use lofty::file::{AudioFile, TaggedFileExt};
+use lofty::file::{AudioFile, FileType, TaggedFileExt};
 use lofty::tag::{Accessor, ItemKey, Tag};
 
 use lx_core::model::song::SongInfo;
+use lx_core::model::source::{AudioProperties, Quality};
 
 static COVER_TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
 const COVER_TEMP_INFIX: &str = ".part.";
@@ -17,6 +18,14 @@ pub fn read_metadata(path: &Path) -> Result<SongInfo, String> {
 
     let properties = tagged.properties();
     let duration = properties.duration();
+    // lofty 未解析出的字段取值为 0
+    let audio = AudioProperties {
+        bitrate: properties.audio_bitrate().filter(|bitrate| *bitrate != 0),
+        sample_rate: properties.sample_rate().filter(|rate| *rate != 0),
+        bit_depth: properties.bit_depth().filter(|depth| *depth != 0),
+        // 位深字段的存在与否是 MP4 的编码判据，取值 0 同样代表存在
+        lossless: is_lossless(tagged.file_type(), properties.bit_depth()),
+    };
 
     // 提取主标签
     let (title, artist, album) = if let Some(tag) = tagged.first_tag() {
@@ -58,7 +67,8 @@ pub fn read_metadata(path: &Path) -> Result<SongInfo, String> {
         album_id: String::new(),
         duration,
         source: lx_core::model::source::SourceId::Local,
-        qualities: std::collections::BTreeSet::from([lx_core::model::source::Quality::High320]),
+        qualities: classify(&audio).into_iter().collect(),
+        audio: Some(audio),
         cover_url: cover_path,
         extra: std::collections::HashMap::new(),
         toggle_source: None,
@@ -67,6 +77,44 @@ pub fn read_metadata(path: &Path) -> Result<SongInfo, String> {
             .extension()
             .and_then(|e| e.to_str())
             .map(|s| s.to_string()),
+    })
+}
+
+/// 判断编码是否无损
+///
+/// 按容器判断的近似结果。WavPack 的 hybrid 模式、格式标记非 PCM 与 IEEE_FLOAT
+/// 的 WAV、带压缩类型的 AIFC 三者实为有损，此处判为无损。三者的准确标识在
+/// `FileProperties` 的转换过程被丢弃，取值需要按具体类型重新解析文件。但实
+/// 际应用场景极其有限因此不做处理。
+fn is_lossless(file_type: FileType, bit_depth: Option<u8>) -> bool {
+    match file_type {
+        FileType::Flac | FileType::Ape | FileType::WavPack | FileType::Wav | FileType::Aiff => true,
+        // AAC、ALAC 与 FLAC 共用 MP4 容器，lofty 只在后两者的解析分支写入位深
+        FileType::Mp4 => bit_depth.is_some(),
+        _ => false,
+    }
+}
+
+/// 将实际编码参数归入 `Quality` 档位
+///
+/// 无损文件的码率随音乐内容浮动，规格取决于位深与采样率。有损文件的码率即规格
+fn classify(audio: &AudioProperties) -> Option<Quality> {
+    if audio.lossless {
+        let hi_res = audio.bit_depth.is_some_and(|depth| depth > 16)
+            || audio.sample_rate.is_some_and(|rate| rate > 48_000);
+        return Some(if hi_res {
+            Quality::Flac24
+        } else {
+            Quality::Flac
+        });
+    }
+    // 码率缺失则无从判断档位
+    let bitrate = audio.bitrate?;
+    // 224 是 128 与 320 的中点
+    Some(if bitrate >= 224 {
+        Quality::High320
+    } else {
+        Quality::Low128
     })
 }
 
@@ -180,8 +228,135 @@ fn simple_hash(data: &[u8]) -> String {
 mod tests {
     use std::io::Cursor;
 
-    use super::{embedded_lyric_from_tag, validate_cover, write_cover_cache};
+    use super::{
+        classify, embedded_lyric_from_tag, is_lossless, validate_cover, write_cover_cache,
+    };
+    use lofty::file::FileType;
     use lofty::tag::{ItemKey, Tag, TagType};
+    use lx_core::model::song::SongInfo;
+    use lx_core::model::source::{AudioProperties, Quality};
+
+    fn audio(
+        lossless: bool,
+        bitrate: u32,
+        sample_rate: u32,
+        bit_depth: Option<u8>,
+    ) -> AudioProperties {
+        AudioProperties {
+            bitrate: Some(bitrate),
+            sample_rate: Some(sample_rate),
+            bit_depth,
+            lossless,
+        }
+    }
+
+    #[test]
+    fn mp4_is_lossless_only_when_a_bit_depth_was_parsed() {
+        assert!(is_lossless(FileType::Mp4, Some(24)));
+        assert!(is_lossless(FileType::Mp4, Some(0)));
+        assert!(!is_lossless(FileType::Mp4, None));
+    }
+
+    #[test]
+    fn container_decides_losslessness_outside_mp4() {
+        assert!(is_lossless(FileType::Flac, None));
+        assert!(is_lossless(FileType::Wav, Some(16)));
+        assert!(!is_lossless(FileType::Mpeg, Some(16)));
+        assert!(!is_lossless(FileType::Opus, None));
+    }
+
+    #[test]
+    fn lossless_files_are_classified_by_depth_and_sample_rate() {
+        let cases = [
+            (audio(true, 5475, 192_000, Some(24)), Quality::Flac24),
+            (audio(true, 900, 44_100, Some(24)), Quality::Flac24),
+            (audio(true, 3000, 96_000, Some(16)), Quality::Flac24),
+            (audio(true, 551, 44_100, Some(16)), Quality::Flac),
+        ];
+        for (audio, expected) in cases {
+            assert_eq!(classify(&audio), Some(expected));
+        }
+    }
+
+    #[test]
+    fn a_high_bitrate_lossless_file_never_lands_in_a_lossy_tier() {
+        let quality = classify(&audio(true, 5475, 192_000, Some(24)));
+        assert!(matches!(quality, Some(Quality::Flac | Quality::Flac24)));
+    }
+
+    #[test]
+    fn lossy_files_are_classified_by_a_midpoint_threshold() {
+        let cases = [
+            (audio(false, 321, 44_100, None), Quality::High320),
+            (audio(false, 224, 44_100, None), Quality::High320),
+            (audio(false, 223, 44_100, None), Quality::Low128),
+            (audio(false, 96, 44_100, None), Quality::Low128),
+        ];
+        for (audio, expected) in cases {
+            assert_eq!(classify(&audio), Some(expected));
+        }
+    }
+
+    #[test]
+    fn a_lossless_file_is_labelled_by_depth_and_sample_rate() {
+        let cases = [
+            (audio(true, 5475, 192_000, Some(24)), "24/192"),
+            (audio(true, 2478, 96_000, Some(24)), "24/96"),
+            (audio(true, 551, 44_100, Some(16)), "16/44.1"),
+            (audio(true, 4000, 176_400, Some(24)), "24/176.4"),
+        ];
+        for (audio, expected) in cases {
+            assert_eq!(audio.label().as_deref(), Some(expected));
+        }
+    }
+
+    #[test]
+    fn a_lossy_file_is_labelled_by_its_measured_bitrate() {
+        let cases = [
+            (audio(false, 321, 44_100, None), "321K"),
+            (audio(false, 320, 44_100, None), "320K"),
+            (audio(false, 220, 44_100, None), "220K"),
+            (audio(false, 107, 44_100, None), "107K"),
+        ];
+        for (audio, expected) in cases {
+            assert_eq!(audio.label().as_deref(), Some(expected));
+        }
+    }
+
+    #[test]
+    fn a_lossless_file_missing_a_bit_depth_falls_back_to_the_sample_rate() {
+        let no_depth = AudioProperties {
+            bitrate: Some(900),
+            sample_rate: Some(44_100),
+            bit_depth: None,
+            lossless: true,
+        };
+
+        assert_eq!(no_depth.label().as_deref(), Some("44.1kHz"));
+    }
+
+    #[test]
+    fn a_lossy_file_without_a_parsed_bitrate_gets_no_tier_at_all() {
+        let unknown = AudioProperties {
+            bitrate: None,
+            sample_rate: Some(44_100),
+            bit_depth: None,
+            lossless: false,
+        };
+
+        assert_eq!(classify(&unknown), None);
+
+        let mut song = SongInfo::new(
+            "1".to_string(),
+            lx_core::model::source::SourceId::Local,
+            "歌曲".to_string(),
+            "歌手".to_string(),
+        );
+        song.qualities = classify(&unknown).into_iter().collect();
+        song.audio = Some(unknown);
+
+        assert_eq!(song.quality_label(), "-");
+    }
 
     #[test]
     fn reads_and_trims_embedded_lyric() {

--- a/source/src/local/mod.rs
+++ b/source/src/local/mod.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 
 use lx_core::model::lyric::LyricData;
 use lx_core::model::song::SongInfo;
-use lx_core::model::source::{Quality, SourceId};
+use lx_core::model::source::{QUALITY_ORDER, Quality, SourceId};
 use lx_core::traits::source::{FetchError, MusicSource, SearchError, SearchResult, SongUrl};
 
 /// 扫描到的本地歌曲（含文件路径）
@@ -217,12 +217,14 @@ impl MusicSource for LocalSource {
             }
         };
 
+        let qualities: Vec<Quality> = song.qualities.iter().copied().collect();
+
         Ok(SongUrl {
             url: path.to_string_lossy().to_string(),
-            quality: Quality::High320,
+            quality: qualities.last().copied().unwrap_or(Quality::High320),
             duration: song.duration,
             cover_url: song.cover_url.clone(),
-            qualities: vec![Quality::High320],
+            qualities,
             headers: vec![],
         })
     }
@@ -254,8 +256,9 @@ impl MusicSource for LocalSource {
         Err(FetchError::NotFound)
     }
 
+    /// 本地文件的规格由文件本身决定，四个档位都可能出现
     fn supported_qualities(&self) -> Vec<Quality> {
-        vec![Quality::High320]
+        QUALITY_ORDER.to_vec()
     }
 }
 


### PR DESCRIPTION
## 问题

- 本地音乐始终显示 `320K` 音质.
- Bilibili 音源的音乐在播放前显示 `-`, 开始播放后变为 `320K`.

## 修复

- 解析本地音乐的真实音质并显示. 因为可以获得准确音质信息所以采取和在线音乐不同的音质表示方式:
  - 有损音乐显示真实比特率, 如 `320K`, `112K`.
  - 无损音乐显示位深/采样率, 如 `24/192`, `16/44.1`.
  - 同时, 因为该表示方式最宽为 8 字符, 拓宽主界面 `音质` 列为 9 字符以避免粘连.
- 消除 status_bar 和 settings 中重复的 quality->label 转换逻辑. 设置页面显示的音质会和之前略有不同, 例如 `320K` 会变为 `320K`, 但这仅影响显示, 不影响设置存储和解析.
- Bilibili 音源显示 `320K` 是在展开分P时硬编码音质造成的, 删掉留空即可.

## 缺陷

- 本地音乐难以归为特定音质档位, 因此显示为实际音质. 当和在线音乐混合播放时音质列会混杂两种不同的语义, 显示效果可能欠佳. 本地无损音乐 位深/采样率 的表示方式和其他音质表示方式之间的视觉落差尤其大.
- 已由的播放列表/历史等持久化存储可能含有错误的音质信息, 但因对整体显示效果的影响并不巨大, 且可通过重新添加以简单解决, 所以未做任何数据迁移.
- 注意到对于 Bilibili 音源, `SongUrl.quality` 实际在 [url.rs](https://github.com/emoeem/voicefox/blob/1bb56ba7a264f598609c9f9e9c5f88c38737fab8/source/src/bili/url.rs) 中被填入了有意义的值, 其他在线音源也都填入了各自请求时指定的音质, 但全仓库除一处测试外无任何代码读取该值. 本着最小修改原则我同样没有使用这个值.
- 底部状态栏显示的音质实际为设置中对在线音源指定的"播放音质", 并不等同于当前音乐的音质, 容易造成混淆. 但这属于另一个话题.

## 效果

<img width="1789" height="1390" alt="image" src="https://github.com/user-attachments/assets/15579545-d868-4ce2-8c23-7a5a7849be58" />
