### PR TITLE
fix(local): 过滤只读事件以避免监听器自激循环

### DIFF
--- a/source/src/local/mod.rs
+++ b/source/src/local/mod.rs
@@ -11,7 +11,8 @@ use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 use async_trait::async_trait;
-use notify::{RecursiveMode, Watcher, recommended_watcher};
+use notify::event::{AccessKind, AccessMode};
+use notify::{EventKind, RecursiveMode, Watcher, recommended_watcher};
 
 use lx_core::model::lyric::LyricData;
 use lx_core::model::song::SongInfo;
@@ -403,7 +404,10 @@ impl LocalSource {
         let stop_thread = Arc::clone(&stop);
         let (wake_tx, wake_rx) = mpsc::channel();
         let (event_tx, event_rx) = mpsc::channel::<notify::Result<notify::Event>>();
-        let mut fs_watcher = recommended_watcher(move |event| {
+        let mut fs_watcher = recommended_watcher(move |event: notify::Result<notify::Event>| {
+            if matches!(&event, Ok(event) if is_non_mutating_access(event)) {
+                return;
+            }
             let _ = event_tx.send(event);
         })
         .map_err(|error| format!("创建文件监听器失败: {error}"))?;
@@ -466,6 +470,16 @@ impl LocalSource {
     pub fn stop_watcher(&self) {
         self.watcher.lock().unwrap().take();
     }
+}
+
+/// 判断事件是否为非破坏性访问，避免监听器自激。
+fn is_non_mutating_access(event: &notify::Event) -> bool {
+    matches!(
+        event.kind,
+        EventKind::Access(AccessKind::Close(AccessMode::Read))
+            | EventKind::Access(AccessKind::Open(_))
+            | EventKind::Access(AccessKind::Read)
+    )
 }
 
 impl Drop for LocalSource {


### PR DESCRIPTION
## 问题

当前在 linux 平台上, 本地音乐文件夹 watcher 会响应包括 `Access(Open(_))` 在内的所有事件, 而该事件可由扫描动作触发, 导致高频重扫, 每秒重扫次数可达 10,000 量级.

## 修复

过滤以下事件, 使它们不被响应:
- `Access(Open(_))`
- `Access(Close(Read))`
- `Access(Read)`

经验证 notify 8.2.0 在 Linux 平台实际并不会产出 `Access(Close(Read))` 与 `Access(Read)`, 保留它们仅出于防御和冗余目的.