### PR TITLE
fix(playback): 修复暂停和恢复播放导致的死锁

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -2911,7 +2911,11 @@ fn toggle_or_start_current(
     settings_page: &Arc<std::sync::Mutex<pages::settings::SettingsPage>>,
     search_seq: &Arc<AtomicU64>,
 ) {
-    match *ctx.player_state.borrow() {
+    // Copy the state out of the watch channel first: pause()/resume() send
+    // a new state into the same watch channel, and a live watch::Ref holds
+    // the RwLock read guard that the send needs as a write lock.
+    let state = *ctx.player_state.borrow();
+    match state {
         PlayerState::Playing | PlayerState::Loading => ctx.player.pause(),
         PlayerState::Paused => ctx.player.resume(),
         PlayerState::Idle | PlayerState::Stopped => {


### PR DESCRIPTION
## 问题

暂停/播放状态切换后:
- 键盘/鼠标等均无响应, 因此无法进行任何操作, 包括恢复播放和退出;
- 无音频播放;
- MPRIS 显示为播放状态, 进度持续推进, 但无法通过 MPRIS 控制实际播放状态;
- 界面卡死, 无更新.

## 定位

TL;DR 典型的死锁. 

e93e6ff 新增的 `toggle_or_start_current()` 在 `match *ctx.player_state.borrow()` 的 arm 里调用 `pause()`/`resume()`, `watch::Ref` 持有读锁并存活到整个 match 结束, 而 `pause()`/`resume()` 内部 `send` 需要同一把写锁, `std::sync::RwLock` 不可重入, 因此死锁.

## 修复

先复制状态再 match.